### PR TITLE
My own pass on cleanups

### DIFF
--- a/administrator/components/com_localise/helpers/localise.php
+++ b/administrator/components/com_localise/helpers/localise.php
@@ -1,236 +1,450 @@
 <?php
-/*------------------------------------------------------------------------
-# com_localise - Localise
-# ------------------------------------------------------------------------
-# author    Mohammad Hasani Eghtedar <m.h.eghtedar@gmail.com>
-# copyright Copyright (C) 2012 http://joomlacode.org/gf/project/com_localise/. All Rights Reserved.
-# @license - http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL
-# Websites: http://joomlacode.org/gf/project/com_localise/
-# Technical Support:  Forum - http://joomlacode.org/gf/project/com_localise/forum/
--------------------------------------------------------------------------*/
-// no direct access
+/**
+ * @package     Localise
+ *
+ * @copyright   Copyright (C) 20014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
 defined('_JEXEC') or die;
+
+jimport('joomla.filesystem.folder');
+jimport('joomla.filesystem.path');
 
 /**
  * Localise Helper class
  *
- * @package    Extensions.Components
+ * @package     Extensions.Components
  * @subpackage  Localise
+ * @since       4.0
  */
-jimport('joomla.filesystem.folder');
-jimport('joomla.filesystem.path');
 abstract class LocaliseHelper
 {
-  static $origins;
-  static $packages;
-  static public function addSubmenu($vName) 
-  {
-    JHtmlSidebar::addEntry(
-      JText::_('COM_LOCALISE_SUBMENU_LANGUAGES'),
-      'index.php?option=com_localise&view=languages',
-      $vName == 'languages'
-    );
-    JHtmlSidebar::addEntry(
-      JText::_('COM_LOCALISE_SUBMENU_TRANSLATIONS'),
-      'index.php?option=com_localise&view=translations',
-      $vName == 'translations'
-    );
-    /*JHtmlSidebar::addEntry(
-      JText::_('COM_LOCALISE_SUBMENU_PACKAGES'),
-      'index.php?option=com_localise&view=packages',
-      $vName == 'packages'
-    );*/
-  }
-  static public function isWritable($path) 
-  {
-    if (JFactory::getConfig()->get('config.ftp_enable')) 
-    {
-      return true;
-    }
-    else
-    {
-      while (!file_exists($path)) 
-      {
-        $path = dirname($path);
-      }
-      return is_writable($path) || JPath::isOwner($path) || JPath::canChmod($path);
-    }
-  }
+	/**
+	 * Array containing the origin information
+	 *
+	 * @var    array
+	 * @since  4.0
+	 */
+	protected static $origins = array('site' => null, 'administrator' => null, 'installation' => null);
 
-	// Check that instalation path exists or not
-	static public function hasInstallation() 
+	/**
+	 * Array containing the package information
+	 *
+	 * @var    array
+	 * @since  4.0
+	 */
+	protected static $packages = array();
+
+	/**
+	 * Prepares the component submenu
+	 *
+	 * @param   string  $vName  Name of the active view
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public static function addSubmenu($vName)
 	{
-		return JFolder::exists(LOCALISEPATH_INSTALLATION);
+		JHtmlSidebar::addEntry(
+			JText::_('COM_LOCALISE_SUBMENU_LANGUAGES'),
+			'index.php?option=com_localise&view=languages',
+			$vName == 'languages'
+		);
+
+		JHtmlSidebar::addEntry(
+			JText::_('COM_LOCALISE_SUBMENU_TRANSLATIONS'),
+			'index.php?option=com_localise&view=translations',
+			$vName == 'translations'
+		);
+
+		/*JHtmlSidebar::addEntry(
+		  JText::_('COM_LOCALISE_SUBMENU_PACKAGES'),
+		  'index.php?option=com_localise&view=packages',
+		  $vName == 'packages'
+		);*/
 	}
 
-  static public function getPackages() 
-  {
-    if (empty(self::$package)) 
-    {
-      self::scanPackages();
-    }
-    return self::$packages;
-  }
-  static protected function scanPackages() 
-  {
-    self::$origins = array('site' => null, 'administrator' => null, 'installation' => null);
-    $model = JModelLegacy::getInstance('Packages', 'LocaliseModel', array('ignore_request' => true));
-    $model->setState('list.start', 0);
-    $model->setState('list.limit', 0);
-    $packages = $model->getItems();
-    self::$packages = array();
-    foreach ($packages as $package) 
-    {
-      self::$packages[$package->name] = $package;
-      foreach ($package->administrator as $file) 
-      {
-        self::$origins['administrator'][$file] = $package->name;
-      }
-      foreach ($package->site as $file) 
-      {
-        self::$origins['site'][$file] = $package->name;
-      }
-      foreach ($package->installation as $file) 
-      {
-        self::$origins['installation'][$file] = $package->name;
-      }
-    }
-  }
-  static public function getOrigin($filename, $client) 
-  {
-    if ($filename == 'override') 
-    {
-      return '_override';
-    }
-    if (!isset(self::$origins)) 
-    {
-      self::scanPackages();
-    }
-    if (isset(self::$origins[$client][$filename])) 
-    {
-      return self::$origins[$client][$filename];
-    }
-    else
-    {
-      return '_thirdparty';
-    }
-  }
-  static public function getScans($client = '', $type = '') 
-  {
-    $params = JComponentHelper::getParams('com_localise');
-    $suffixes = explode(',',$params->get('suffixes', '.sys,.menu'));
+	/**
+	 * Determines if a given path is writable in the current environment
+	 *
+	 * @param   string  $path  Path to check
+	 *
+	 * @return  boolean  True if writable
+	 *
+	 * @since   4.0
+	 */
+	public static function isWritable($path)
+	{
+		if (JFactory::getConfig()->get('config.ftp_enable'))
+		{
+			return true;
+		}
+		else
+		{
+			while (!file_exists($path))
+			{
+				$path = dirname($path);
+			}
 
-    $filter_type = $type ? $type : '.';
-    $filter_client = $client ? $client : '.';
-    $scans = array();
-    if (preg_match("/$filter_client/", 'installation')) 
-    {
-      // Scan installation folders
-      
-    }
-    if (preg_match("/$filter_client/", 'administrator')) 
-    {
-      // Scan administrator folders
-      if (preg_match("/$filter_type/", 'component')) 
-      {
-        // Scan administrator components folders
-        $scans[] = array('prefix' => '', 'suffix' => '', 'type' => 'component', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/components/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => '', 'suffix' => $suffix, 'type' => 'component', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/components/', 'folder' => '');
-        }
-      }
-      if (preg_match("/$filter_type/", 'module')) 
-      {
-        // Scan administrator modules folders
-        $scans[] = array('prefix' => '', 'suffix' => '', 'type' => 'module', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/modules/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => '', 'suffix' => $suffix, 'type' => 'module', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/modules/', 'folder' => '');
-        }
-      }
-      if (preg_match("/$filter_type/", 'template')) 
-      {
-        // Scan administrator templates folders
-        $scans[] = array('prefix' => 'tpl_', 'suffix' => '', 'type' => 'template', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/templates/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => 'tpl_', 'suffix' => $suffix, 'type' => 'template', 'client' => 'administrator', 'path' => LOCALISEPATH_ADMINISTRATOR . '/templates/', 'folder' => '');
-        }
-      }
-    }
-    if (preg_match("/$filter_client/", 'site')) 
-    {
-      // Scan site folders
-      if (preg_match("/$filter_type/", 'component')) 
-      {
-        // Scan site components folders
-        $scans[] = array('prefix' => '', 'suffix' => '', 'type' => 'component', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/components/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => '', 'suffix' => $suffix, 'type' => 'component', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/components/', 'folder' => '');
-        }
-      }
-      if (preg_match("/$filter_type/", 'module')) 
-      {
-        // Scan site modules folders
-        $scans[] = array('prefix' => '', 'suffix' => '', 'type' => 'module', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/modules/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => '', 'suffix' => $suffix, 'type' => 'module', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/modules/', 'folder' => '');
-        }
-      }
-      if (preg_match("/$filter_type/", 'template')) 
-      {
-        // Scan site templates folders
-        $scans[] = array('prefix' => 'tpl_', 'suffix' => '', 'type' => 'template', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/templates/', 'folder' => '');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => 'tpl_', 'suffix' => $suffix, 'type' => 'template', 'client' => 'site', 'path' => LOCALISEPATH_SITE . '/templates/', 'folder' => '');
-        }
-      }
-    }
-    if (preg_match("/$filter_type/", 'plugin')) 
-    {
-      // Scan plugins folders
-      $plugin_types = JFolder::folders(JPATH_PLUGINS);
-      foreach ($plugin_types as $plugin_type) 
-      {
-        // Scan plugins site folders
-        // $scans[] = array('prefix' => 'plg_' . $plugin_type . '_', 'suffix' => '', 'type' => 'plugin', 'client' => 'site', 'path' => JPATH_ROOT . "/plugins/$plugin_type/", 'folder' => '');
+			return is_writable($path) || JPath::isOwner($path) || JPath::canChmod($path);
+		}
+	}
 
-        // Scan plugins administrator folders
-        $scans[] = array('prefix' => 'plg_' . $plugin_type . '_', 'suffix' => '', 'type' => 'plugin', 'client' => 'administrator', 'path' => JPATH_PLUGINS . "/$plugin_type/", 'folder' => '/administrator');
-        foreach($suffixes as $suffix) {
-          $scans[] = array('prefix' => 'plg_' . $plugin_type . '_', 'suffix' => $suffix, 'type' => 'plugin', 'client' => 'administrator', 'path' => JPATH_PLUGINS . "/$plugin_type/", 'folder' => '/administrator');
-        }
-      }
-    }
-    return $scans;
-  }
+	/**
+	 * Check if the installation path exists
+	 *
+	 * @return  boolean  True if the installation path exists
+	 *
+	 * @since   4.0
+	 */
+	public static function hasInstallation()
+	{
+		return is_dir(LOCALISEPATH_INSTALLATION);
+	}
 
-	// Get file id in database with file path
-	public static function getFileId($path) 
+	/**
+	 * Retrieve the packages array
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0
+	 */
+	public static function getPackages()
+	{
+		if (empty(static::$packages))
+		{
+			static::scanPackages();
+		}
+
+		return static::$packages;
+	}
+
+	/**
+	 * Scans the filesystem for language files in each package
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	protected static function scanPackages()
+	{
+		$model         = JModelLegacy::getInstance('Packages', 'LocaliseModel', array('ignore_request' => true));
+		$model->setState('list.start', 0);
+		$model->setState('list.limit', 0);
+		$packages       = $model->getItems();
+
+		foreach ($packages as $package)
+		{
+			static::$packages[$package->name] = $package;
+
+			foreach ($package->administrator as $file)
+			{
+				static::$origins['administrator'][$file] = $package->name;
+			}
+
+			foreach ($package->site as $file)
+			{
+				static::$origins['site'][$file] = $package->name;
+			}
+
+			foreach ($package->installation as $file)
+			{
+				static::$origins['installation'][$file] = $package->name;
+			}
+		}
+	}
+
+	/**
+	 * Retrieves the origin information
+	 *
+	 * @param   string  $filename  The filename to check
+	 * @param   string  $client    The client to check
+	 *
+	 * @return  string  Origin data
+	 *
+	 * @since   4.0
+	 */
+	public static function getOrigin($filename, $client)
+	{
+		if ($filename == 'override')
+		{
+			return '_override';
+		}
+
+		// If the $origins array doesn't contain data, fill it
+		if (empty(static::$origins['site']))
+		{
+			static::scanPackages();
+		}
+
+		if (isset(static::$origins[$client][$filename]))
+		{
+			return static::$origins[$client][$filename];
+		}
+		else
+		{
+			return '_thirdparty';
+		}
+	}
+
+	/**
+	 * Scans the filesystem
+	 *
+	 * @param   string  $client  The client to scan
+	 * @param   string  $type    The extension type to scan
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0
+	 */
+	public static function getScans($client = '', $type = '')
+	{
+		$params   = JComponentHelper::getParams('com_localise');
+		$suffixes = explode(',', $params->get('suffixes', '.sys,.menu'));
+
+		$filter_type   = $type ? $type : '.';
+		$filter_client = $client ? $client : '.';
+		$scans         = array();
+
+		// Scan installation folders
+		if (preg_match("/$filter_client/", 'installation'))
+		{
+			// TODO ;-)
+		}
+
+		// Scan administrator folders
+		if (preg_match("/$filter_client/", 'administrator'))
+		{
+			// Scan administrator components folders
+			if (preg_match("/$filter_type/", 'component'))
+			{
+				$scans[] = array(
+					'prefix' => '',
+					'suffix' => '',
+					'type'   => 'component',
+					'client' => 'administrator',
+					'path'   => LOCALISEPATH_ADMINISTRATOR . '/components/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => '',
+						'suffix' => $suffix,
+						'type'   => 'component',
+						'client' => 'administrator',
+						'path'   => LOCALISEPATH_ADMINISTRATOR . '/components/',
+						'folder' => ''
+					);
+				}
+			}
+
+			// Scan administrator modules folders
+			if (preg_match("/$filter_type/", 'module'))
+			{
+				$scans[] = array(
+					'prefix' => '',
+					'suffix' => '',
+					'type'   => 'module',
+					'client' => 'administrator',
+					'path'   => LOCALISEPATH_ADMINISTRATOR . '/modules/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => '',
+						'suffix' => $suffix,
+						'type'   => 'module',
+						'client' => 'administrator',
+						'path'   => LOCALISEPATH_ADMINISTRATOR . '/modules/',
+						'folder' => ''
+					);
+				}
+			}
+
+			// Scan administrator templates folders
+			if (preg_match("/$filter_type/", 'template'))
+			{
+				$scans[] = array(
+					'prefix' => 'tpl_',
+					'suffix' => '',
+					'type'   => 'template',
+					'client' => 'administrator',
+					'path'   => LOCALISEPATH_ADMINISTRATOR . '/templates/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => 'tpl_',
+						'suffix' => $suffix,
+						'type'   => 'template',
+						'client' => 'administrator',
+						'path'   => LOCALISEPATH_ADMINISTRATOR . '/templates/',
+						'folder' => ''
+					);
+				}
+			}
+		}
+
+		// Scan site folders
+		if (preg_match("/$filter_client/", 'site'))
+		{
+			// Scan site components folders
+			if (preg_match("/$filter_type/", 'component'))
+			{
+				$scans[] = array(
+					'prefix' => '',
+					'suffix' => '',
+					'type'   => 'component',
+					'client' => 'site',
+					'path'   => LOCALISEPATH_SITE . '/components/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => '',
+						'suffix' => $suffix,
+						'type'   => 'component',
+						'client' => 'site',
+						'path'   => LOCALISEPATH_SITE . '/components/',
+						'folder' => ''
+					);
+				}
+			}
+
+			// Scan site modules folders
+			if (preg_match("/$filter_type/", 'module'))
+			{
+				$scans[] = array(
+					'prefix' => '',
+					'suffix' => '',
+					'type'   => 'module',
+					'client' => 'site',
+					'path'   => LOCALISEPATH_SITE . '/modules/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => '',
+						'suffix' => $suffix,
+						'type'   => 'module',
+						'client' => 'site',
+						'path'   => LOCALISEPATH_SITE . '/modules/',
+						'folder' => ''
+					);
+				}
+			}
+
+			// Scan site templates folders
+			if (preg_match("/$filter_type/", 'template'))
+			{
+				$scans[] = array(
+					'prefix' => 'tpl_',
+					'suffix' => '',
+					'type'   => 'template',
+					'client' => 'site',
+					'path'   => LOCALISEPATH_SITE . '/templates/',
+					'folder' => ''
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => 'tpl_',
+						'suffix' => $suffix,
+						'type'   => 'template',
+						'client' => 'site',
+						'path'   => LOCALISEPATH_SITE . '/templates/',
+						'folder' => ''
+					);
+				}
+			}
+		}
+
+		// Scan plugins folders
+		if (preg_match("/$filter_type/", 'plugin'))
+		{
+			$plugin_types = JFolder::folders(JPATH_PLUGINS);
+
+			foreach ($plugin_types as $plugin_type)
+			{
+				// Scan administrator language folders as this is where plugin languages are installed
+				$scans[] = array(
+					'prefix' => 'plg_' . $plugin_type . '_',
+					'suffix' => '',
+					'type'   => 'plugin',
+					'client' => 'administrator',
+					'path'   => JPATH_PLUGINS . "/$plugin_type/",
+					'folder' => '/administrator'
+				);
+
+				foreach ($suffixes as $suffix)
+				{
+					$scans[] = array(
+						'prefix' => 'plg_' . $plugin_type . '_',
+						'suffix' => $suffix,
+						'type'   => 'plugin',
+						'client' => 'administrator',
+						'path'   => JPATH_PLUGINS . "/$plugin_type/",
+						'folder' => '/administrator'
+					);
+				}
+			}
+		}
+
+		return $scans;
+	}
+
+	/**
+	 * Get file ID in the database for the given file path
+	 *
+	 * @param   string  $path  Path to lookup
+	 *
+	 * @return  integer  File ID
+	 *
+	 * @since   4.0
+	 */
+	public static function getFileId($path)
 	{
 		static $fileIds = null;
 
-		if (!isset($fileIds)) 
+		if (!isset($fileIds))
 		{
-			$db    = JFactory::getDBO();
-			$query = $db->getQuery(true);
+			$db = JFactory::getDbo();
 
-			$query->select('id, path');
-			$query->from($db->quoteName('#__localise'));
+			$db->setQuery(
+			   $db->getQuery(true)
+					->select($db->quoteName(array('id, path')))
+					->from($db->quoteName('#__localise'))
+			);
 
-			$db->setQuery($query);
 			$fileIds = $db->loadObjectList('path');
 		}
 
-		jimport('joomla.filesystem.file');
-
-		if (JFile::exists($path) || preg_match('/.ini$/', $path)) 
+		if (is_file($path) || preg_match('/.ini$/', $path))
 		{
-			if (!array_key_exists($path, $fileIds)) 
+			if (!array_key_exists($path, $fileIds))
 			{
 				JTable::addIncludePath(JPATH_COMPONENT . '/tables');
-				$table = JTable::getInstance('Localise', 'LocaliseTable');
+
+				/* @type  LocaliseTableLocalise  $table */
+				$table       = JTable::getInstance('Localise', 'LocaliseTable');
 				$table->path = $path;
 				$table->store();
-				$fileIds[$path] = new JObject(array('id' => $table->id));
+
+				$fileIds[$path] = new stdClass;
+				$fileIds[$path]->id = $table->id;
 			}
 
 			return $fileIds[$path]->id;
@@ -243,214 +457,248 @@ abstract class LocaliseHelper
 		return $id;
 	}
 
-  /**
-   * Gets a list of the actions that can be performed.
-   *
-   * @param int The file ID.
-   *
-   * @return JObject
-   */
-  public static function getActions($fileId = 0) 
-  {
-    $user = JFactory::getUser();
-    $result = new JObject;
-    if (empty($fileId)) 
-    {
-      $assetName = 'com_localise';
-    }
-    else
-    {
-      $assetName = 'com_localise.' . (int)$fileId;
-    }
-    $actions = array('core.admin', 'core.manage', 'localise.create', 'localise.edit', 'localise.delete');
-    foreach ($actions as $action) 
-    {
-      $result->set($action, $user->authorise($action, $assetName));
-    }
-    return $result;
-  }
+	/**
+	 * Find a translation file
+	 *
+	 * @param   string  $client    Client to lookup
+	 * @param   string  $tag       Language tag to lookup
+	 * @param   string  $filename  Filename to lookup
+	 *
+	 * @return  string  Path to the requrested file
+	 *
+	 * @since   4.0
+	 */
+	public static function findTranslationPath($client, $tag, $filename)
+	{
+		$path = static::getTranslationPath($client, $tag, $filename, 'local');
 
-  /**
-   * Find a translation file
-   */
-  public static function findTranslationPath($client, $tag, $filename) 
-  {
-    $path = self::getTranslationPath($client, $tag, $filename, 'local');
-    if (!JFile::exists($path)) 
-    {
-      $path = self::getTranslationPath($client, $tag, $filename, 'global');;
-    }
-    return $path;
-  }
+		if (!is_file($path))
+		{
+			$path = static::getTranslationPath($client, $tag, $filename, 'global');
+		}
 
-  /**
-   * Get a translation path
-   */
-  public static function getTranslationPath($client, $tag, $filename, $storage) 
-  {
-    $path = null;
-    if ($filename == 'override') 
-    {
-      $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/overrides/$tag.override.ini";
-    }
-    elseif ($filename == 'joomla') 
-    {
-      $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
-    }
-    elseif ($storage == 'global') 
-    {
-      $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$filename.ini";
-    }
-    else
-    {
-      $parts = explode('.', $filename);
-      $extension = $parts[0];
-      switch (substr($extension, 0, 3)) 
-      {
-        case 'com':
-          $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/components/$extension/language/$tag/$tag.$filename.ini";
-        break;
-        case 'mod':
-          $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/modules/$extension/language/$tag/$tag.$filename.ini";
-        break;
-        case 'plg':
-          $parts = explode('_', $extension);
-          $group = $parts[1];
-          $plugin = substr($filename, 5 + strlen($group));
-          $path = JPATH_PLUGINS . "/$group/$plugin/language/$tag/$tag.$filename.ini";
-        break;
-        case 'tpl':
-          $template = substr($extension, 4);
-          $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/templates/$template/language/$tag/$tag.$filename.ini";
-        break;
-        case 'lib':
-          $path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$filename.ini";
-          if (!JFile::exists($path))
-            $path = $client == 'administrator' ? LOCALISEPATH_SITE : LOCALISE_ADMINISTRATOR . "/language/$tag/$tag.$filename.ini";
-        break;
-      }
-    }
-    return $path;
-  }
+		return $path;
+	}
 
-  /**
-   * Load a language file for translating the package name
-   */
-  public static function loadLanguage($extension, $client = null) 
-  {
-    $extension = strtolower($extension);
-    $lang = JFactory::getLanguage();
-    $prefix = substr($extension, 0, 3);
-    switch ($prefix) 
-    {
-    case 'com':
-      $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/components/$extension/", null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), $lang->getDefault(), false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/components/$extension/", $lang->getDefault(), false, false);
-    break;
-    case 'mod':
-      $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/modules/$extension/", null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), $lang->getDefault(), false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/modules/$extension/", $lang->getDefault(), false, false);
-    break;
-    case 'plg':
-      $lang->load($extension, LOCALISEPATH_ADMINISTRATOR, null, false, false) || $lang->load($extension, LOCALISEPATH_ADMINISTRATOR . "/components/$extension/", null, false, false) || $lang->load($extension, LOCALISEPATH_ADMINISTRATOR, $lang->getDefault(), false, false) || $lang->load($extension, LOCALISEPATH_ADMINISTRATOR . "/components/$extension/", $lang->getDefault(), false, false);
-    break;
-    case 'tpl':
-      $template = substr($extension, 4);
-      $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/templates/$template/", null, false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), $lang->getDefault(), false, false) || $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/templates/$template/", $lang->getDefault(), false, false);
-    break;
-    case 'lib':
-    case 'fil':
-    case 'pkg':
-      $lang->load($extension, JPATH_ROOT, null, false, false) || $lang->load($extension, JPATH_ROOT, $lang->getDefault(), false, false);
-    break;
-    }
-  }
-  public static function parseSections($filename) 
-  {
-    static $sections;
-    if (!isset($sections)) 
-    {
-      $sections = array();
-    }
-    if (!array_key_exists($filename, $sections)) 
-    {
-      if (file_exists($filename)) 
-      {
-        $error = '';
-        if (!defined('_QQ_')) define('_QQ_', '"');
-        ini_set('track_errors', '1');
-        $version = phpversion();
-        if ($version >= "5.3.1") 
-        {
-          $contents = file_get_contents($filename);
-          $contents = str_replace('_QQ_', '"\""', $contents);
-          $strings = @parse_ini_string($contents, true);
-          if (!empty($php_errormsg)) 
-          {
-            $error = "Error parsing " . basename($filename) . ": $php_errormsg";
-          }
-        }
-        else
-        {
-          $strings = @parse_ini_file($filename, true);
-          if (!empty($php_errormsg)) 
-          {
-            $error = $php_errormsg;
-          }
-        }
-        ini_restore('track_errors');
-        if ($strings !== false) 
-        {
-          $default = array();
-          foreach ($strings as $key => $value) 
-          {
-            if (is_string($value)) 
-            {
-              $default[$key] = $value;
-              unset($strings[$key]);
-            }
-            else
-            {
-              break;
-            }
-          }
-          if (!empty($default)) 
-          {
-            $strings = array_merge(array('Default' => $default), $strings);
-          }
-          if ($version == "5.3.0") 
-          {
-            foreach ($strings as $section => $value) 
-            {
-              foreach ($value as $key => $string) 
-              {
-                $strings[$section][$key] = str_replace('_QQ_', '"', $string);
-              }
-            }
-          }
-          $keys = array();
-          foreach ($strings as $section => $value) 
-          {
-            foreach ($value as $key => $string) 
-            {
-              $keys[$key] = $strings[$section][$key];
-            }
-          }
-        }
-        else
-        {
-          $keys = false;
-        }
-        $sections[$filename] = array('sections' => $strings, 'keys' => $keys, 'error' => $error);
-      }
-      else
-      {
-        $sections[$filename] = array('sections' => array(), 'keys' => array(), 'error' => '');
-      }
-    }
-    if (!empty($sections[$filename]['error'])) 
-    {
-      $model = JModelLegacy::getInstance('Translation', 'LocaliseModel');
-      $model->setError($sections[$filename]['error']);
-    }
-    return $sections[$filename];
-  }
+	/**
+	 * Get a translation path
+	 *
+	 * @param   string  $client    Client to lookup
+	 * @param   string  $tag       Language tag to lookup
+	 * @param   string  $filename  Filename to lookup
+	 * @param   string  $storage   Storage location to check
+	 *
+	 * @return  string  Path to the requrested file
+	 *
+	 * @since   4.0
+	 */
+	public static function getTranslationPath($client, $tag, $filename, $storage)
+	{
+		if ($filename == 'override')
+		{
+			$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/overrides/$tag.override.ini";
+		}
+		elseif ($filename == 'joomla')
+		{
+			$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
+		}
+		elseif ($storage == 'global')
+		{
+			$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$filename.ini";
+		}
+		else
+		{
+			$parts     = explode('.', $filename);
+			$extension = $parts[0];
+
+			switch (substr($extension, 0, 3))
+			{
+				case 'com':
+					$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/components/$extension/language/$tag/$tag.$filename.ini";
+
+					break;
+
+				case 'mod':
+					$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/modules/$extension/language/$tag/$tag.$filename.ini";
+
+					break;
+
+				case 'plg':
+					$parts  = explode('_', $extension);
+					$group  = $parts[1];
+					$plugin = substr($filename, 5 + strlen($group));
+					$path   = JPATH_PLUGINS . "/$group/$plugin/language/$tag/$tag.$filename.ini";
+
+					break;
+
+				case 'tpl':
+					$template = substr($extension, 4);
+					$path     = constant('LOCALISEPATH_' . strtoupper($client)) . "/templates/$template/language/$tag/$tag.$filename.ini";
+
+					break;
+
+				case 'lib':
+					$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$filename.ini";
+
+					if (!is_file($path))
+					{
+						$path = $client == 'administrator' ? LOCALISEPATH_SITE : LOCALISE_ADMINISTRATOR . "/language/$tag/$tag.$filename.ini";
+					}
+
+					break;
+
+				default   :
+					$path = '';
+
+					break;
+			}
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Load a language file for translating the package name
+	 *
+	 * @param   string  $extension  The extension to load
+	 * @param   string  $client     The client from where to load the file
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public static function loadLanguage($extension, $client)
+	{
+		$extension = strtolower($extension);
+		$lang      = JFactory::getLanguage();
+		$prefix    = substr($extension, 0, 3);
+
+		switch ($prefix)
+		{
+			case 'com':
+				$lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, true)
+					|| $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/components/$extension/", null, false, true);
+
+				break;
+
+			case 'mod':
+				$lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, true)
+					|| $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/modules/$extension/", null, false, true);
+
+				break;
+
+			case 'plg':
+				$lang->load($extension, LOCALISEPATH_ADMINISTRATOR, null, false, true)
+					|| $lang->load($extension, LOCALISEPATH_ADMINISTRATOR . "/components/$extension/", null, false, true);
+
+				break;
+
+			case 'tpl':
+				$template = substr($extension, 4);
+				$lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)), null, false, true)
+					|| $lang->load($extension, constant('LOCALISEPATH_' . strtoupper($client)) . "/templates/$template/", null, false, true);
+
+				break;
+
+			case 'lib':
+			case 'fil':
+			case 'pkg':
+				$lang->load($extension, JPATH_ROOT, null, false, true);
+
+				break;
+		}
+	}
+
+	/**
+	 * Parses the sections of a language file
+	 *
+	 * @param   string  $filename  The filename to parse
+	 *
+	 * @return  array  Array containing the file data
+	 *
+	 * @since   4.0
+	 */
+	public static function parseSections($filename)
+	{
+		static $sections = array();
+
+		if (!array_key_exists($filename, $sections))
+		{
+			if (file_exists($filename))
+			{
+				$error = '';
+
+				if (!defined('_QQ_'))
+				{
+					define('_QQ_', '"');
+				}
+
+				ini_set('track_errors', '1');
+				$version = phpversion();
+
+				$contents = file_get_contents($filename);
+				$contents = str_replace('_QQ_', '"\""', $contents);
+				$strings  = @parse_ini_string($contents, true);
+
+				if (!empty($php_errormsg))
+				{
+					$error = "Error parsing " . basename($filename) . ": $php_errormsg";
+				}
+
+				ini_restore('track_errors');
+
+				if ($strings !== false)
+				{
+					$default = array();
+
+					foreach ($strings as $key => $value)
+					{
+						if (is_string($value))
+						{
+							$default[$key] = $value;
+
+							unset($strings[$key]);
+						}
+						else
+						{
+							break;
+						}
+					}
+
+					if (!empty($default))
+					{
+						$strings = array_merge(array('Default' => $default), $strings);
+					}
+
+					$keys = array();
+
+					foreach ($strings as $section => $value)
+					{
+						foreach ($value as $key => $string)
+						{
+							$keys[$key] = $strings[$section][$key];
+						}
+					}
+				}
+				else
+				{
+					$keys = false;
+				}
+
+				$sections[$filename] = array('sections' => $strings, 'keys' => $keys, 'error' => $error);
+			}
+			else
+			{
+				$sections[$filename] = array('sections' => array(), 'keys' => array(), 'error' => '');
+			}
+		}
+
+		if (!empty($sections[$filename]['error']))
+		{
+			$model = JModelLegacy::getInstance('Translation', 'LocaliseModel');
+			$model->setError($sections[$filename]['error']);
+		}
+
+		return $sections[$filename];
+	}
 }

--- a/administrator/components/com_localise/helpers/localise.php
+++ b/administrator/components/com_localise/helpers/localise.php
@@ -59,11 +59,11 @@ abstract class LocaliseHelper
 			$vName == 'translations'
 		);
 
-		/*JHtmlSidebar::addEntry(
-		  JText::_('COM_LOCALISE_SUBMENU_PACKAGES'),
-		  'index.php?option=com_localise&view=packages',
-		  $vName == 'packages'
-		);*/
+		JHtmlSidebar::addEntry(
+			JText::_('COM_LOCALISE_SUBMENU_PACKAGES'),
+			'index.php?option=com_localise&view=packages',
+			$vName == 'packages'
+		);
 	}
 
 	/**
@@ -424,7 +424,7 @@ abstract class LocaliseHelper
 			$db = JFactory::getDbo();
 
 			$db->setQuery(
-			   $db->getQuery(true)
+				$db->getQuery(true)
 					->select($db->quoteName(array('id, path')))
 					->from($db->quoteName('#__localise'))
 			);

--- a/administrator/components/com_localise/views/languages/view.html.php
+++ b/administrator/components/com_localise/views/languages/view.html.php
@@ -30,7 +30,7 @@ class LocaliseViewLanguages extends JViewLegacy
 	 *
 	 * @return  void
 	 */
-	function display($tpl = null) 
+	function display($tpl = null)
 	{
 		// Get the data
 		$this->items      = $this->get('Items');
@@ -41,7 +41,7 @@ class LocaliseViewLanguages extends JViewLegacy
 		LocaliseHelper::addSubmenu('languages');
 
 		// Check for errors.
-		if (count($errors = $this->get('Errors'))) 
+		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode("\n", $errors));
 			return false;
@@ -60,19 +60,19 @@ class LocaliseViewLanguages extends JViewLegacy
 	 *
 	 * @since   1.6
 	 */
-	protected function addToolbar() 
+	protected function addToolbar()
 	{
-		$canDo = LocaliseHelper::getActions();
+		$canDo = JHelperContent::getActions('com_localise', 'component');
 
 		JToolbarHelper::title(JText::sprintf('COM_LOCALISE_HEADER_MANAGER', JText::_('COM_LOCALISE_HEADER_LANGUAGES')), 'comments-2 langmanager');
 
-		if ($canDo->get('localise.create')) 
+		if ($canDo->get('localise.create'))
 		{
 			JToolbarHelper::addNew('language.add');
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin')) 
+		if ($canDo->get('core.admin'))
 		{
 			JToolbarHelper::preferences('com_localise');
 			JToolbarHelper::divider();

--- a/administrator/components/com_localise/views/packages/view.html.php
+++ b/administrator/components/com_localise/views/packages/view.html.php
@@ -27,7 +27,7 @@ class LocaliseViewPackages extends JViewLegacy
 	 *
 	 * @return  void
 	 */
-	function display($tpl = null) 
+	function display($tpl = null)
 	{
 		// Get the data
 		$this->items = $this->get('Items');
@@ -38,7 +38,7 @@ class LocaliseViewPackages extends JViewLegacy
 		LocaliseHelper::addSubmenu('packages');
 
 		// Check for errors.
-		if (count($errors = $this->get('Errors'))) 
+		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode('<br />', $errors));
 			return false;
@@ -55,34 +55,34 @@ class LocaliseViewPackages extends JViewLegacy
 		parent::display($tpl);
 	}
 
-	protected function prepareDocument() 
+	protected function prepareDocument()
 	{
 		$document = JFactory::getDocument();
-		$document->setTitle(JText::sprintf('COM_LOCALISE_TITLE', JText::_('COM_LOCALISE_TITLE_PACKAGES')));   
+		$document->setTitle(JText::sprintf('COM_LOCALISE_TITLE', JText::_('COM_LOCALISE_TITLE_PACKAGES')));
 	}
- 
-	protected function addToolbar() 
+
+	protected function addToolbar()
 	{
-		$canDo = LocaliseHelper::getActions();
+		$canDo = JHelperContent::getActions('com_localise', 'component');
 
 		JToolBarHelper::title(JText::sprintf('COM_LOCALISE_HEADER_MANAGER', JText::_('COM_LOCALISE_HEADER_PACKAGES')), 'install');
 
-		if ($canDo->get('localise.create')) 
+		if ($canDo->get('localise.create'))
 		{
 			JToolbarHelper::addNew('package.add');
 		}
 
-		if ($canDo->get('localise.edit')) 
+		if ($canDo->get('localise.edit'))
 		{
 			JToolbarHelper::editList('package.edit');
 		}
 
-		if ($canDo->get('localise.create') || $canDo->get('localise.edit')) 
+		if ($canDo->get('localise.create') || $canDo->get('localise.edit'))
 		{
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('localise.delete')) 
+		if ($canDo->get('localise.delete'))
 		{
 			JToolbarHelper::deleteList('COM_LOCALISE_MSG_PACKAGES_VALID_DELETE', 'packages.delete');
 			JToolBarHelper::divider();
@@ -93,13 +93,13 @@ class LocaliseViewPackages extends JViewLegacy
 		JToolBarHelper::custom('package.language', 'archive.png', 'archive.png', 'COM_LOCALISE_TOOLBAR_PACKAGES_LANGUAGE', true);
 		JToolbarHelper::divider();
 
-		if ($canDo->get('package.batch')) 
+		if ($canDo->get('package.batch'))
 		{
 			JToolBarHelper::custom('package.batch', 'refresh.png', 'refresh.png', 'COM_LOCALISE_TOOLBAR_PACKAGES_BATCH', true);
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin')) 
+		if ($canDo->get('core.admin'))
 		{
 			JToolbarHelper::preferences('com_localise');
 			JToolbarHelper::divider();

--- a/administrator/components/com_localise/views/translations/view.html.php
+++ b/administrator/components/com_localise/views/translations/view.html.php
@@ -30,7 +30,7 @@ class LocaliseViewTranslations extends JViewLegacy
 	 *
 	 * @return  void
 	 */
-	function display($tpl = null) 
+	function display($tpl = null)
 	{
 		// Get the data
 		$this->items      = $this->get('Items');
@@ -42,7 +42,7 @@ class LocaliseViewTranslations extends JViewLegacy
 		LocaliseHelper::addSubmenu('translations');
 
 		// Check for errors.
-		if (count($errors = $this->get('Errors'))) 
+		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode("<br />", $errors));
 			return false;
@@ -61,13 +61,13 @@ class LocaliseViewTranslations extends JViewLegacy
 	 *
 	 * @since   1.6
 	 */
-	protected function addToolbar() 
+	protected function addToolbar()
 	{
-		$canDo = LocaliseHelper::getActions();
+		$canDo = JHelperContent::getActions('com_localise', 'component');
 
 		JToolbarHelper::title(JText::sprintf('COM_LOCALISE_HEADER_MANAGER', JText::_('COM_LOCALISE_HEADER_TRANSLATIONS')), 'comments-2 langmanager');
 
-		if ($canDo->get('core.admin')) 
+		if ($canDo->get('core.admin'))
 		{
 			JToolbarHelper::preferences('com_localise');
 			JToolbarHelper::divider();

--- a/localise.xml
+++ b/localise.xml
@@ -6,10 +6,10 @@
 	<author>Christophe Demko</author>
 	<author>Jean-Marie Simonet</author>
 	<author>Ifan Evans</author>
-	<copyright>(C) 2005 - 2013 Open Source Matters. All rights reserved.</copyright>
-	<authorEmail>m.h.eghtedar@gmail.com</authorEmail>
-	<authorUrl>http://joomlacode.org/gf/project/com_localise/</authorUrl>
-	<version>3.2.1</version>
+	<copyright>(C) 2014 Open Source Matters. All rights reserved.</copyright>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>https://github.com/joomla-projects/com_localise</authorUrl>
+	<version>4.0.0-dev</version>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<description>COM_LOCALISE_XML_DESCRIPTION</description>
 	<install>


### PR DESCRIPTION
- Updates the component manifest for the forked version
- Bumps the component version to `4.0.0-dev`
- First pass on cleanup of `LocaliseHelper` to include:
  - Code style with doc blocks to better identify methods purposes
  - Removes `LocaliseHelper::getActions()` in favor of `JHelperContent::getActions()`
  - Optimizes the language loading code based on the default loading en-GB handling in core
  - Drops code checking PHP versions unsupported by 3.3
  - Use less of the Filesystem package and more native PHP where appropriate
