### PR TITLE
Filtering broken in managers

### DIFF
--- a/administrator/components/com_localise/models/languages.php
+++ b/administrator/components/com_localise/models/languages.php
@@ -30,7 +30,7 @@ class LocaliseModelLanguages extends JModelList
 	protected function populateState($ordering = null, $direction = null)
 	{
 		$app  = JFactory::getApplication();
-		$data = $app->input->get('filters');
+		$data = $app->input->get('filters', array(), 'array');
 
 		if (empty($data))
 		{

--- a/administrator/components/com_localise/models/packages.php
+++ b/administrator/components/com_localise/models/packages.php
@@ -30,7 +30,7 @@ class LocaliseModelPackages extends JModelList
 	protected function populateState($ordering = null, $direction = null)
 	{
 		$app  = JFactory::getApplication();
-		$data = $app->input->get('filters');
+		$data = $app->input->get('filters', array(), 'array');
 
 		if (empty($data))
 		{

--- a/administrator/components/com_localise/models/translations.php
+++ b/administrator/components/com_localise/models/translations.php
@@ -31,7 +31,7 @@ class LocaliseModelTranslations extends JModelList
 	protected function populateState($ordering = null, $direction = null)
 	{
 		$app  = JFactory::getApplication();
-		$data = $app->input->get('filters');
+		$data = $app->input->get('filters', array(), 'array');
 
 		if (empty($data))
 		{


### PR DESCRIPTION
( ! ) Notice: Array to string conversion in /Applications/MAMP/htdocs/trunkgitnew/libraries/joomla/filter/input.php on line 233
( ! ) Warning: Illegal string offset 'select' in /Applications/MAMP/htdocs/trunkgitnew/administrator/components/com_localise/models/languages.php on line 43
( ! ) Warning: Illegal string offset 'search' in /Applications/MAMP/htdocs/trunkgitnew/administrator/components/com_localise/models/languages.php on line 44

Same for the translations view.

To test, use;
index.php?option=com_localise&view=translations
index.php?option=com_localise&view=languages

Also corrected the packages view.
