### PR TITLE
Remvoving nbproject folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Desktop.ini
 
 # Netbeans (custom)
 .netbeans/*
+/nbproject/*
 
 # Temp files
 *.tmp


### PR DESCRIPTION
Just ignoring the project folder for Netbeans projects where the projectinfo is stored inside the project folder
