### PR TITLE
Fix date bug #45

### DIFF
--- a/administrator/components/com_localise/models/forms/language.xml
+++ b/administrator/components/com_localise/models/forms/language.xml
@@ -120,7 +120,7 @@
 			description="COM_LOCALISE_LABEL_LANGUAGE_VERSION_DESC" />
 		<field
 			name="creationDate"
-			type="calendar"
+			type="text"
 			default="now"
 			label="COM_LOCALISE_LABEL_LANGUAGE_CREATIONDATE"
 			description="COM_LOCALISE_LABEL_LANGUAGE_CREATIONDATE_DESC" />

--- a/administrator/components/com_localise/views/languages/tmpl/default_body.php
+++ b/administrator/components/com_localise/views/languages/tmpl/default_body.php
@@ -50,7 +50,7 @@ $user   = JFactory::getUser();
 		</a>
 	</td>
 	<td class="center hidden-phone"><?php if (isset($item->version)) echo $item->version; ?></td>
-	<td class="center hidden-phone"><?php if (isset($item->creationDate)) echo JHtml::_('date', $item->creationDate, JText::_('DATE_FORMAT_LC3')); ?></td>
+	<td class="center hidden-phone"><?php if (isset($item->creationDate)) echo $item->creationDate; ?></td>
 	<td class="hidden-phone">
 		<span class="hasTooltip" title="<b><?php echo JText::_('COM_LOCALISE_TOOLTIP_LANGUAGES_AUTHOR_INFORMATION') . '</b><br />' . (isset($item->authorEmail) ? ($item->authorEmail . '<br />') :'') . (isset($item->authorUrl)?$item->authorUrl:''); ?>">
 			<?php if (isset($item->author)) echo $item->author; ?>


### PR DESCRIPTION
The component no longer crashes when encountering a strange date format as JDate is no longer used to parse dates. Instead the field is simply displayed as it is.
