### PR TITLE
Search for the two packages in media folder

### DIFF
--- a/administrator/components/com_localise/models/packages.php
+++ b/administrator/components/com_localise/models/packages.php
@@ -73,22 +73,28 @@ class LocaliseModelPackages extends JModelList
 		{
 			$search = $this->getState('filter.search');
 			$this->packages = array();
-			$path = JPATH_COMPONENT_ADMINISTRATOR . '/packages';
+			$paths = array (
+				JPATH_COMPONENT_ADMINISTRATOR . '/packages',
+				JPATH_SITE . '/media/com_localise/packages',
+			);
 
-			if (JFolder::exists($path))
+			foreach ($paths as $path)
 			{
-				$files = JFolder::files($path, '\.xml$');
-
-				foreach ($files as $file)
+				if (JFolder::exists($path))
 				{
-					$model = JModelLegacy::getInstance('Package', 'LocaliseModel', array('ignore_request' => true));
-					$id    = LocaliseHelper::getFileId("$path/$file");
-					$model->setState('package.id', $id);
-					$package = $model->getItem();
-
-					if (empty($search) || preg_match("/$search/i", $package->title))
+					$files = JFolder::files($path, '\.xml$');
+		
+					foreach ($files as $file)
 					{
-						$this->packages[] = $package;
+						$model = JModelLegacy::getInstance('Package', 'LocaliseModel', array('ignore_request' => true));
+						$id    = LocaliseHelper::getFileId("$path/$file");
+						$model->setState('package.id', $id);
+						$package = $model->getItem();
+		
+						if (empty($search) || preg_match("/$search/i", $package->title))
+						{
+							$this->packages[] = $package;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Currently the component doesn't recognise core language files because their located in the media folder.

Apply patch and go to translations and you'll see tooltips (displayed on top of each other helpfully - UI fixes are going to be needed after this) showing the core files. 

Note that the list files is not upto date. You may wish to update them before testing. (PR https://github.com/joomla-projects/com_localise/pull/86 deals with the updates needed)
