### PR TITLE
Implementing icons for core files when necessary in the translations view. Correcting code style

### DIFF
--- a/administrator/components/com_localise/views/translations/tmpl/default_body.php
+++ b/administrator/components/com_localise/views/translations/tmpl/default_body.php
@@ -16,7 +16,7 @@ $packages = LocaliseHelper::getPackages();
 $user = JFactory::getUser();
 $lang = JFactory::getLanguage();
 ?>
-<?php foreach ($this->items as $i => $item): ?>
+<?php foreach ($this->items as $i => $item) : ?>
 	<?php $canEdit = $user->authorise('localise.edit', 'com_localise' . (isset($item->id) ? ('.' . $item->id) : '')); ?>
 	<tr class="<?php echo $item->state; ?> row<?php echo $i % 2; ?>">
 		<td width="20" class="center hidden-phone"><?php echo $i + 1; ?></td>
@@ -34,109 +34,108 @@ $lang = JFactory::getLanguage();
 					'translate'      => false
 				)
 			); ?>
-			<?php if ($item->origin == '_thirdparty'): ?>
+			<?php if ($item->origin == '_thirdparty') : ?>
 				<?php echo JHtml::_('jgrid.action', $i, '', array('tip' => true, 'inactive_title' => JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ORIGIN_THIRDPARTY'), 'inactive_class' => '16-thirdparty', 'enabled' => false, 'translate' => false)); ?>
-			<?php elseif ($item->origin == '_override'): ?>
+			<?php elseif ($item->origin == '_override') : ?>
 				<?php echo JHtml::_('jgrid.action', $i, '', array('tip' => true, 'inactive_title' => JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ORIGIN_OVERRIDE'), 'inactive_class' => '16-override', 'enabled' => false, 'translate' => false)); ?>
-			<?php
-			else: ?>
-				<span class="jgrid hasTooltip"
-				      title="<?php echo JText::_($packages[$item->origin]->title) . '::' . JText::_($packages[$item->origin]->description); ?>">
-			<span class="state"
-			      style="background-image:url(<?php echo JURI::root(true) . $packages[$item->origin]->icon; ?>);">
-				<span class="text"/>
-			</span>
-		</span>
-		<?php endif; ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_'.$item->state, $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-'.$item->state, 'enabled' => false, 'translate'=>false)); ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_TYPE_'.$item->type), 'inactive_class'=>'16-'.$item->type, 'enabled' => false, 'translate'=>false)); ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_CLIENT_'.$item->client), 'inactive_class'=>'16-'.$item->client, 'enabled' => false, 'translate'=>false)); ?>
-		<?php if ($item->tag==$reference && $item->type!='override'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_REFERENCE'), 'inactive_class'=>'16-reference', 'enabled' => false, 'translate'=>false));?>
-		<?php else: ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
-		<?php endif; ?></td>
-	<td dir="ltr" class="center"><?php echo $item->tag; ?></td>
-        <td dir="ltr" class="center"><?php echo $item->client ?></td>
-	<td dir="ltr">
-		<?php if (!empty($item->checked_out)) : ?>
-		<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
-		<?php else: ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
-		<?php endif; ?>
-		<?php if ($item->writable && !$item->error && $canEdit): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
-		<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)).($item->filename=='override' ? '&layout=raw' :''));?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">
-			<?php echo $item->name; ?>.ini
-		</a>
-		<?php elseif (!$canEdit): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTEDITABLE', substr($item->path, strlen(JPATH_ROOT))), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
-		<?php echo $item->name;?>.ini
-		<?php elseif (!$item->writable): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTWRITABLE', substr($item->path, strlen(JPATH_ROOT))), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
-		<?php echo $item->name;?>.ini
-		<?php elseif ($item->filename=='override'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
-		<?php echo $item->name; ?>.ini
-		<?php else: ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ERROR', substr($item->path, strlen(JPATH_ROOT)) , implode(', ',$item->error)), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
-		<?php echo $item->name; ?>.ini
-                <?php endif;?>
-		<?php if ($item->writable && $canEdit): ?>
-		(<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client=' . $item->client . '&tag=' . $item->tag . '&filename=' . $item->filename . '&storage=' . $item->storage . '&id=' . LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)) . '&layout=raw'); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEWRAW' : 'EDITRAW')); ?>"><?php echo JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_SOURCE'); ?></a>)
-		<?php else: ?>
-		<?php echo substr($item->path,strlen(JPATH_ROOT)); ?>
-		<?php endif;?>
-	</td>
-	<td width="100" class="center" dir="ltr">
-		<?php if ($item->bom != 'UTF-8'): ?>
-		<a class="jgrid hasTooltip" href="http://en.wikipedia.org/wiki/UTF-8" title="<?php echo addslashes(htmlspecialchars(JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_UTF8'), ENT_COMPAT, 'UTF-8')); ?>">
-			<span class="state icon-16-error"></span>
-			<span class="text"></span>
-		</a>
-		<?php elseif ($item->state == 'error'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ERROR',substr($item->path,strlen(JPATH_ROOT)) , implode(', ',$item->error)), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false));?>
-		<?php elseif ($item->type == 'override'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_TYPE_OVERRIDE'), 'inactive_class'=>'16-override', 'enabled' => false, 'translate'=>false));?>
-		<?php elseif ($item->state == 'notinreference'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_NOTINREFERENCE'), 'inactive_class'=>'16-notinreference', 'enabled' => false, 'translate'=>false));?>
-		<?php elseif ($item->state == 'unexisting'): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_UNEXISTING', $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-unexisting', 'enabled' => false, 'translate'=>false));?>
-		<?php elseif ($item->tag == $reference): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_REFERENCE'), 'inactive_class'=>'16-reference', 'enabled' => false, 'translate'=>false));?>
-		<?php elseif ($item->translated == $item->total || $item->complete): ?>
-		<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_COMPLETE', $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-complete', 'enabled' => false, 'translate'=>false));?>
-		<?php else: ?>
-		<span class="hasTooltip" title="<?php echo $item->translated + $item->unchanged == 0 ? JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTSTARTED') : JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_INPROGRESS', $item->translated, $item->unchanged, $item->total, $item->extra);?>">
-			<?php $translated =  $item->total ? intval(100 * $item->translated / $item->total) : 0;?>
-			<?php $unchanged =  ($item->translated+$item->unchanged==$item->total)?(100-$translated):($item->total ? intval(100 * $item->unchanged / $item->total) : 0);?>
-			<?php if ($item->unchanged):?>
-			( <?php echo $translated;?> %+ <?php echo $unchanged;?> %)
-			<?php else:?>
-			<?php echo $translated;?> %
+			<?php else : ?>
+				<?php if ($packages[$item->origin]->title == 'com_localise_package_core') : ?>
+					<?php $icon = 'core'; ?>
+				<?php else : ?>
+					<?php $icon = 'other'; ?>
+				<?php endif; ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip' => true, 'inactive_title' => JText::_($packages[$item->origin]->title) . '::' . JText::_($packages[$item->origin]->description), 'inactive_class' => '16-' . $icon, 'enabled' => false, 'translate' => false)); ?>
+			<?php endif; ?>
+			<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_'.$item->state, $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-'.$item->state, 'enabled' => false, 'translate'=>false)); ?>
+			<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_TYPE_'.$item->type), 'inactive_class'=>'16-'.$item->type, 'enabled' => false, 'translate'=>false)); ?>
+			<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_CLIENT_'.$item->client), 'inactive_class'=>'16-'.$item->client, 'enabled' => false, 'translate'=>false)); ?>
+			<?php if ($item->tag == $reference && $item->type != 'override') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_REFERENCE'), 'inactive_class'=>'16-reference', 'enabled' => false, 'translate'=>false));?>
+			<?php else : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
+			<?php endif; ?>
+		</td>
+		<td dir="ltr" class="center"><?php echo $item->tag; ?></td>
+		<td dir="ltr" class="center"><?php echo $item->client ?></td>
+		<td dir="ltr">
+			<?php if (!empty($item->checked_out)) : ?>
+				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
+			<?php else : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
+			<?php endif; ?>
+			<?php if ($item->writable && !$item->error && $canEdit) : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
+				<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)).($item->filename=='override' ? '&layout=raw' :''));?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">
+				<?php echo $item->name; ?>.ini
+				</a>
+			<?php elseif (!$canEdit) : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTEDITABLE', substr($item->path, strlen(JPATH_ROOT))), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
+				<?php echo $item->name;?>.ini
+			<?php elseif (!$item->writable) : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTWRITABLE', substr($item->path, strlen(JPATH_ROOT))), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
+				<?php echo $item->name;?>.ini
+			<?php elseif ($item->filename=='override') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('enabled'=>false)); ?>
+				<?php echo $item->name; ?>.ini
+			<?php else : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ERROR', substr($item->path, strlen(JPATH_ROOT)) , implode(', ',$item->error)), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
+				<?php echo $item->name; ?>.ini
 			<?php endif;?>
-			<div style="text-align:left;border:solid silver 1px;width:100px;height:4px;">
-				<div class="pull-left" style="height:100%; width:<?php echo $translated;?>% ;background:green;">
-				</div>
-				<div class="pull-left" style="height:100%; width:<?php echo $unchanged;?>% ;background:orange;">
-				</div>
-				<div class="pull-left" style="height:100%; width:<?php echo 100-$translated-$unchanged;?>% ;background:red;">
-				</div>
-			</div>
-			<div class="clr"></div>
-		</span>
+			<?php if ($item->writable && $canEdit) : ?>
+				(<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client=' . $item->client . '&tag=' . $item->tag . '&filename=' . $item->filename . '&storage=' . $item->storage . '&id=' . LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)) . '&layout=raw'); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEWRAW' : 'EDITRAW')); ?>"><?php echo JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_SOURCE'); ?></a>)
+			<?php else : ?>
+				<?php echo substr($item->path,strlen(JPATH_ROOT)); ?>
+			<?php endif;?>
+		</td>
+		<td width="100" class="center" dir="ltr">
+			<?php if ($item->bom != 'UTF-8') : ?>
+				<a class="jgrid hasTooltip" href="http://en.wikipedia.org/wiki/UTF-8" title="<?php echo addslashes(htmlspecialchars(JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_UTF8'), ENT_COMPAT, 'UTF-8')); ?>">
+				<span class="state icon-16-error"></span>
+				<span class="text"></span>
+				</a>
+			<?php elseif ($item->state == 'error') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_ERROR',substr($item->path,strlen(JPATH_ROOT)) , implode(', ',$item->error)), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false));?>
+			<?php elseif ($item->type == 'override') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_TYPE_OVERRIDE'), 'inactive_class'=>'16-override', 'enabled' => false, 'translate'=>false));?>
+			<?php elseif ($item->state == 'notinreference') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_NOTINREFERENCE'), 'inactive_class'=>'16-notinreference', 'enabled' => false, 'translate'=>false));?>
+			<?php elseif ($item->state == 'unexisting') : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_STATE_UNEXISTING', $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-unexisting', 'enabled' => false, 'translate'=>false));?>
+			<?php elseif ($item->tag == $reference) : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_REFERENCE'), 'inactive_class'=>'16-reference', 'enabled' => false, 'translate'=>false));?>
+			<?php elseif ($item->translated == $item->total || $item->complete) : ?>
+				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_COMPLETE', $item->translated, $item->unchanged, $item->total, $item->extra), 'inactive_class'=>'16-complete', 'enabled' => false, 'translate'=>false));?>
+			<?php else : ?>
+				<span class="hasTooltip" title="<?php echo $item->translated + $item->unchanged == 0 ? JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTSTARTED') : JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_INPROGRESS', $item->translated, $item->unchanged, $item->total, $item->extra);?>">
+				<?php $translated =  $item->total ? intval(100 * $item->translated / $item->total) : 0;?>
+				<?php $unchanged =  ($item->translated+$item->unchanged==$item->total)?(100-$translated):($item->total ? intval(100 * $item->unchanged / $item->total) : 0);?>
+					<?php if ($item->unchanged):?>
+						( <?php echo $translated;?> %+ <?php echo $unchanged;?> %)
+					<?php else :?>
+						<?php echo $translated;?> %
+					<?php endif;?>
+					<div style="text-align:left;border:solid silver 1px;width:100px;height:4px;">
+						<div class="pull-left" style="height:100%; width:<?php echo $translated;?>% ;background:green;">
+						</div>
+						<div class="pull-left" style="height:100%; width:<?php echo $unchanged;?>% ;background:orange;">
+						</div>
+						<div class="pull-left" style="height:100%; width:<?php echo 100-$translated-$unchanged;?>% ;background:red;">
+						</div>
+					</div>
+					<div class="clr"></div>
+				</span>
 			<?php endif; ?>
 		</td>
 		<td dir="ltr" class="center">
-			<?php if ($item->state != 'error'): ?>
-				<?php if ($item->state == 'notinreference'): ?>
+			<?php if ($item->state != 'error') : ?>
+				<?php if ($item->state == 'notinreference') : ?>
 					<?php echo $item->extra; ?>
-				<?php elseif ($item->type == 'override'): ?>
+				<?php elseif ($item->type == 'override') : ?>
 				<?php
-				elseif ($item->tag == $reference): ?>
+				elseif ($item->tag == $reference) : ?>
 					<?php echo $item->translated; ?>
 				<?php
-				else: ?>
+				else : ?>
 					<?php echo ($item->unchanged ? ("(" . $item->translated . "+" . $item->unchanged . ")") : $item->translated) . "/" . $item->total . ($item->extra ? "+" . $item->extra : ''); ?>
 				<?php endif; ?>
 			<?php endif; ?>
@@ -147,8 +146,8 @@ $lang = JFactory::getLanguage();
 				<?php if ($description || $item->author) : ?>
 					<?php $author = $item->author ? $item->author : JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_AUTHOR'); ?>
 					<span class="hasTooltip" title="<?php echo htmlspecialchars($description, ENT_COMPAT, 'UTF-8'); ?>">
-			<?php echo $author; ?>
-		</span>
+					<?php echo $author; ?>
+				</span>
 				<?php endif; ?>
 			<?php endif; ?>
 		</td>

--- a/administrator/components/com_localise/views/translations/tmpl/default_legend.php
+++ b/administrator/components/com_localise/views/translations/tmpl/default_legend.php
@@ -44,13 +44,15 @@ defined('_JEXEC') or die;
 					</tr>
 					<?php foreach ($this->packages as $package): ?>
 						<tr class="row<?php echo $i = 1 - $i; ?>">
-							<td align="center">
-								<span class="jgrid hasTip" title="<?php echo JText::_($package->title); ?>">
-									<span class="state"
-									      style="background-image:url(<?php echo JURI::root(true) . $package->icon; ?>);">
-										<span class="text"></span>
-									</span>
-								</span>
+							<?php if ($package->title == 'com_localise_package_core') : ?>
+								<td align="center"><i
+								title="<?php echo JText::_($package->title); ?>"
+								class="btn btn-micro disabled icon-16-core hasTooltip"></i></td>
+							<?php else : ?>
+								<td align="center"><i
+								title="<?php echo JText::_($package->title); ?>"
+								class="btn btn-micro disabled icon-16-other hasTooltip"></i></td>
+							<?php endif; ?>
 							<td><?php echo JText::_($package->description); ?></td>
 							<td><?php echo JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_ORIGIN'); ?></td>
 						</tr>

--- a/media/com_localise/css/localise.css
+++ b/media/com_localise/css/localise.css
@@ -67,7 +67,11 @@
 	color: #EF8F00;
 }
 .icon-16-core:before {
-	content: "!";
+	content: "\e200";
+	color: #000000;
+}
+.icon-16-other:before {
+	content: "\e239";
 	color: #796D67;
 }
 .icon-16-thirdparty:before,

--- a/media/com_localise/packages/core.xml
+++ b/media/com_localise/packages/core.xml
@@ -3,7 +3,6 @@
 	<title>com_localise_package_core</title>
 	<description>com_localise_package_core_desc</description>
 	<manifest client="administrator">com_localise</manifest>
-	<icon>/images/joomla-black.png</icon>
 	<author>Joomla! Project</author>
 	<maincopyright>Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.</maincopyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/media/com_localise/packages/localise.xml
+++ b/media/com_localise/packages/localise.xml
@@ -4,7 +4,6 @@
   <title>com_localise_package_localise</title>
   <description>com_localise_package_localise_desc</description>
   <manifest client="administrator">com_localise</manifest>
-  <icon>/administrator/templates/bluestork/images/menu/icon-16-language.png</icon>
   <author>Localise Team</author>
   <maincopyright>Copyright (C) 2012 - today Localise Team. All rights reserved.</maincopyright>
   <license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>


### PR DESCRIPTION
After patch
for legend:
![screen shot 2014-06-02 at 11 44 57](https://cloud.githubusercontent.com/assets/869724/3145665/c28fc574-ea3a-11e3-8f19-df3fdfbeac30.png)
for body
![screen shot 2014-06-02 at 11 45 57](https://cloud.githubusercontent.com/assets/869724/3145668/cbe26a6e-ea3a-11e3-946f-fb55d5678b1d.png)
