### PR TITLE
Rework how core lang pack is loaded for localise view

### DIFF
--- a/administrator/components/com_localise/helpers/localise.php
+++ b/administrator/components/com_localise/helpers/localise.php
@@ -131,7 +131,13 @@ abstract class LocaliseHelper
 	 */
 	protected static function scanPackages()
 	{
-		$model         = JModelLegacy::getInstance('Packages', 'LocaliseModel', array('ignore_request' => true));
+		// We need to add in the core and localise packages here.
+		$paths = array(
+			JPATH_SITE . '/media/com_localise/packages',
+		);
+
+		// Get the model instance
+		$model         = JModelLegacy::getInstance('Packages', 'LocaliseModel', array('ignore_request' => true, 'paths' => $paths));
 		$model->setState('list.start', 0);
 		$model->setState('list.limit', 0);
 		$packages       = $model->getItems();

--- a/administrator/components/com_localise/models/packages.php
+++ b/administrator/components/com_localise/models/packages.php
@@ -22,11 +22,77 @@ jimport('joomla.filesystem.file');
  */
 class LocaliseModelPackages extends JModelList
 {
+	/**
+	 * The item context.
+	 *
+	 * @var  string
+	 */
 	protected $context = 'com_localise.packages';
 
+	/**
+	 * The list of packages with filtering.
+	 *
+	 * @var  array
+	 */
 	protected $items;
 
+	/**
+	 * The full list of packages.
+	 *
+	 * @var  array
+	 */
 	protected $packages;
+
+	/**
+	 * A list of paths to search for XML files.
+	 *
+	 * @var  array
+	 */
+	protected $paths;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *
+	 * @see     JModelList
+	 * @since   4.0
+	 */
+	public function __construct($config = array())
+	{
+		if (isset($config['paths']))
+		{
+			if (is_array($config['paths']))
+			{
+				foreach ($config['paths'] as $possiblePath)
+				{
+					$this->addPath($possiblePath);
+				}
+			}
+			else
+			{
+				$this->addPath($config['paths']);
+			}
+		}
+
+		$this->addPath(JPATH_COMPONENT_ADMINISTRATOR . '/packages');
+
+		parent::__construct($config);
+	}
+
+	/**
+	 * Method to add a path to a package.
+	 *
+	 * @param   string  $path   An path to a folder containing XML packages.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function addPath($path)
+	{
+		$this->paths[] = $path;
+	}
 
 	/**
 	 * Method to auto-populate the model state.
@@ -73,10 +139,7 @@ class LocaliseModelPackages extends JModelList
 		{
 			$search = $this->getState('filter.search');
 			$this->packages = array();
-			$paths = array (
-				JPATH_COMPONENT_ADMINISTRATOR . '/packages',
-				JPATH_SITE . '/media/com_localise/packages',
-			);
+			$paths = $this->paths;
 
 			foreach ($paths as $path)
 			{


### PR DESCRIPTION
Currently editing the core language pack was completely broken because of it's custom path. And, to be honest I don't really think that it needs to be edited anyhow as the core stuff is kinda set in stone.

So after this patch if you go to the packages view only custom packages will show. However in the translations view packs are still recognized as either core, localise or 3rd party
