### PR TITLE
Correcting some errors for core package creation

### DIFF
--- a/administrator/components/com_localise/models/fields/origin.php
+++ b/administrator/components/com_localise/models/fields/origin.php
@@ -66,7 +66,7 @@ class JFormFieldOrigin extends JFormField
 		$packages_options = array();
 
 		/** We took off the packages icons (due to bootstrap implementation)
-		 * This may need review
+		 * @Todo: this may need review
 		foreach ($packages as $package)
 		{
 			$packages_options[] = JHtml::_(

--- a/administrator/components/com_localise/models/fields/origin.php
+++ b/administrator/components/com_localise/models/fields/origin.php
@@ -65,6 +65,8 @@ class JFormFieldOrigin extends JFormField
 		$packages         = LocaliseHelper::getPackages();
 		$packages_options = array();
 
+		/** We took off the packages icons (due to bootstrap implementation)
+		 * This may need review
 		foreach ($packages as $package)
 		{
 			$packages_options[] = JHtml::_(
@@ -82,6 +84,7 @@ class JFormFieldOrigin extends JFormField
 				$attributes .= ' style="background-image: url(' . JURI::root(true) . $package->icon . ');"';
 			}
 		}
+		*/
 
 		$packages_options = JArrayHelper::sortObjects($packages_options, 'text');
 		$thirdparty       = JHtml::_('select.option', '_thirdparty', JText::sprintf('COM_LOCALISE_OPTION_TRANSLATIONS_ORIGIN_THIRDPARTY'), array('option.attr' => 'attributes', 'attr' => 'class="iconlist-16-thirdparty"'));

--- a/administrator/components/com_localise/models/forms/package.xml
+++ b/administrator/components/com_localise/models/forms/package.xml
@@ -27,6 +27,7 @@
 			id="description"
 			name="description"
 			type="textarea"
+			filter="safehtml"
 			label="COM_LOCALISE_LABEL_PACKAGE_DESCRIPTION"
 			description="COM_LOCALISE_LABEL_PACKAGE_DESCRIPTION_DESC" />
 		<field
@@ -40,6 +41,7 @@
 			id="version"
 			name="version"
 			type="text"
+			required="true"
 			label="COM_LOCALISE_LABEL_PACKAGE_VERSION"
 			description="COM_LOCALISE_LABEL_PACKAGE_VERSION_DESC" />
 		<field
@@ -57,7 +59,9 @@
 		<field
 			id="authorurl"
 			name="authorurl"
-			type="text"
+			type="url"
+			filter="url"
+			validate="url"
 			label="COM_LOCALISE_LABEL_PACKAGE_AUTHORURL"
 			description="COM_LOCALISE_LABEL_PACKAGE_AUTHORURL_DESC" />
 		<field
@@ -77,7 +81,9 @@
 		<field
 			id="url"
 			name="url"
-			type="text"
+			type="url"
+			filter="url"
+			validate="url"
 			label="COM_LOCALISE_LABEL_PACKAGE_URL"
 			description="COM_LOCALISE_LABEL_PACKAGE_URL_DESC" />
 		<field
@@ -89,7 +95,9 @@
 		<field
 			id="packagerurl"
 			name="packagerurl"
-			type="text"
+			type="url"
+			filter="url"
+			validate="url"
 			label="COM_LOCALISE_LABEL_PACKAGE_PACKAGERURL"
 			description="COM_LOCALISE_LABEL_PACKAGE_PACKAGERURL_DESC" />
 		<field
@@ -101,7 +109,9 @@
 		<field
 			id="serverurl"
 			name="serverurl"
-			type="text"
+			type="url"
+			filter="url"
+			validate="url"
 			label="COM_LOCALISE_LABEL_PACKAGE_SERVERURL"
 			description="COM_LOCALISE_LABEL_PACKAGE_SERVERURL_DESC" />
 		<field

--- a/administrator/components/com_localise/models/package.php
+++ b/administrator/components/com_localise/models/package.php
@@ -729,7 +729,7 @@ class LocaliseModelPackage extends JModelForm
 			$admin_txt .= "\t".'<description>' . $data['language'] . 'site language</description>' . "\n";
 			$admin_txt .= "\t".'<files>'. "\n";
 
-			foreach ($site as $translation)
+			foreach ($administrator as $translation)
 			{
 				$file_data = JFile::read(JPATH_ROOT . '/administrator/language/'.$data['language'].'/'.$data['language'].'.'.$translation.'.ini');
 				if(!empty($file_data)){

--- a/administrator/components/com_localise/models/package.php
+++ b/administrator/components/com_localise/models/package.php
@@ -228,7 +228,6 @@ class LocaliseModelPackage extends JModelForm
 				$package->client      = $client;
 				$package->standalone  = substr($manifest, 0, 4) == 'fil_';
 				$package->core        = ((string) $xml->attributes()->core) == 'true';
-				$package->icon        = (string) $xml->icon;
 				$package->title       = (string) $xml->title;
 				$package->version     = (string) $xml->version;
 				$package->description = (string) $xml->description;
@@ -346,7 +345,7 @@ class LocaliseModelPackage extends JModelForm
 		$package  = $this->getItem();
 		$path     = JPATH_COMPONENT_ADMINISTRATOR . "/packages/$name.xml";
 		$manifest = $package->manifest ? $package->manifest : ('fil_localise_package_' . $name);
-		$client   = $package->client ? $package->client : 'site';
+		//$client   = $package->client ? $package->client : 'site';
 
 		if ($package->standalone)
 		{
@@ -365,18 +364,20 @@ class LocaliseModelPackage extends JModelForm
 			$authorElement = $dom->createElement('author', $data['author']);
 			$copyrightElement = $dom->createElement('copyright', $data['copyright']);
 			$licenseElement = $dom->createElement('license', $data['license']);
-			$authorEmailElement = $dom->createElement('authorEmail', $data['authoremail']);
-			$authorUrlElement = $dom->createElement('authorUrl', $data['authorurl']);
+			$authorEmailElement = $dom->createElement('authoremail', $data['authoremail']);
+			$authorUrlElement = $dom->createElement('authorurl', $data['authorurl']);
 			$languageElement = $dom->createElement('language', $data['language']);
 			$copyrightElement = $dom->createElement('copyright', $data['copyright']);
 			$urlElement = $dom->createElement('url', $data['url']);
 			$packagerElement = $dom->createElement('packager', $data['packager']);
-			$packagerUrlElement = $dom->createElement('packagerUrl', $data['packagerurl']);
+			$packagerUrlElement = $dom->createElement('packagerurl', $data['packagerurl']);
+			$servernameElement = $dom->createElement('servername', $data['servername']);
+			$serverurlElement = $dom->createElement('serverurl', $data['serverurl']);
 
 			// Set the client attribute on the manifest element
-			$clientAttribute = $dom->createAttribute('client');
-			$clientAttribute->value = $client;
-			$manifestElement->appendChild($clientAttribute);
+			//$clientAttribute = $dom->createAttribute('client');
+			//$clientAttribute->value = $client;
+			//$manifestElement->appendChild($clientAttribute);
 
 			// Add all the elements to the parent <package> tag
 			$packageXml->appendChild($titleElement);
@@ -393,6 +394,8 @@ class LocaliseModelPackage extends JModelForm
 			$packageXml->appendChild($urlElement);
 			$packageXml->appendChild($packagerElement);
 			$packageXml->appendChild($packagerUrlElement);
+			$packageXml->appendChild($servernameElement);
+			$packageXml->appendChild($serverurlElement);
 
 			$administrator = array();
 			$site          = array();
@@ -457,7 +460,7 @@ class LocaliseModelPackage extends JModelForm
 
 				$packageXml->appendChild($installXml);
 			}
-			
+
 			$dom->appendChild($packageXml);
 
 			// Set FTP credentials, if given.
@@ -782,11 +785,11 @@ class LocaliseModelPackage extends JModelForm
 		}
 
 
-		$text .= '</files>' . "\n";
+		$text .= "\t" . '</files>' . "\n";
 		if(!empty($data['serverurl'])){
-			$text .= '<updateservers>' . "\n";
-			$text .= '<server type="collection" priority="1" name="'.$data['servername'].'">'.$data['serverurl'].'</server>' . "\n";
-			$text .= '</updateservers>' . "\n";
+			$text .= "\t" . '<updateservers>' . "\n";
+			$text .= "\t\t" . '<server type="collection" priority="1" name="'.$data['servername'].'">'.$data['serverurl'].'</server>' . "\n";
+			$text .= "\t" . '</updateservers>' . "\n";
 		}
 		$text .= '</extension>' . "\n";
 
@@ -817,7 +820,7 @@ class LocaliseModelPackage extends JModelForm
 		header("Expires: 0");
 		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 		header('Content-Type: application/zip');
-		header('Content-Disposition: attachment; filename="' . $data['language'].'.'.str_replace(' ','_',$data['name']).'.'.$data['version'] . '.zip"');
+		header('Content-Disposition: attachment; filename="' . $data['language'] . '_joomla_lang_full_' . substr_replace($data['version'], 'v', 5, -1) . '.zip"');
 		header('Content-Length: '.strlen($zipdata));
 		header("Cache-Control: maxage=1");
 		header("Pragma: public");

--- a/administrator/components/com_localise/views/packages/tmpl/default_body.php
+++ b/administrator/components/com_localise/views/packages/tmpl/default_body.php
@@ -25,7 +25,7 @@ $canAdmin = $user->authorise('core.admin', 'com_localise');
 	</td>
 	<td>
 		<?php LocaliseHelper::loadLanguage($item->manifest, $item->client);?>
-		<span title="<?php echo JText::_($item->title);?>::<?php echo JText::_($item->description);?>" class="hasTooltip localise-icon "></span>
+		<span title="<?php echo JText::_($item->title); ?>" class="hasTooltip localise-icon "></span>
 		<?php if (!$canAdmin): ?>
 			<span title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_PACKAGES_READONLY'); ?>"  class="hasTooltip localise-icon icon-16-warning">
 				<?php echo JText::sprintf('COM_LOCALISE_TEXT_PACKAGES_TITLE',JText::_($item->title),$item->name); ?>

--- a/administrator/components/com_localise/views/packages/tmpl/default_body.php
+++ b/administrator/components/com_localise/views/packages/tmpl/default_body.php
@@ -25,7 +25,7 @@ $canAdmin = $user->authorise('core.admin', 'com_localise');
 	</td>
 	<td>
 		<?php LocaliseHelper::loadLanguage($item->manifest, $item->client);?>
-		<span title="<?php echo JText::_($item->title);?>::<?php echo JText::_($item->description);?>" class="hasTooltip localise-icon " style="background-image:url(<?php echo JURI::root(true) . '/' . $item->icon;?>);"></span>
+		<span title="<?php echo JText::_($item->title);?>::<?php echo JText::_($item->description);?>" class="hasTooltip localise-icon "></span>
 		<?php if (!$canAdmin): ?>
 			<span title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_PACKAGES_READONLY'); ?>"  class="hasTooltip localise-icon icon-16-warning">
 				<?php echo JText::sprintf('COM_LOCALISE_TEXT_PACKAGES_TITLE',JText::_($item->title),$item->name); ?>


### PR DESCRIPTION
This saves all fields in the package xml, and lets create a core-compliant language pack.

It is not a final approach to the general packages creation where one should have the choice between a 3pd extension lang (or langs) file type pack and core.
(See http://docs.joomla.org/J2.5:Making_non-core_language_packs )
Also, for core packs, translator should have the choice to include css,  js (in media) for example

Even with this patch we still have some issues for core packs as not all ini files are included (tpl, and also some files for no apparent reason: mod_version, mod_multilangstatus, main ini file.
