### PR TITLE
Coping with some Core inis not included in reference

### DIFF
--- a/administrator/components/com_localise/models/translations.php
+++ b/administrator/components/com_localise/models/translations.php
@@ -360,6 +360,37 @@ class LocaliseModelTranslations extends JModelList
 				{
 					foreach ($files as $file)
 					{
+						// Coping with Core files not considered as reference
+						if ($file == $reftag . '.com_messages.ini' || $file == $reftag . '.com_mailto.sys.ini'
+							|| $file == $reftag . '.com_wrapper.ini'|| $file == $reftag . '.com_wrapper.sys.ini')
+						{
+							$reftaglength = strlen($reftag);
+
+							$name	= substr($file, 0, -4);
+							$name	= substr($name, $reftaglength + 1);
+
+							$origin	= LocaliseHelper::getOrigin($name, $client);
+
+							foreach ($tags as $tag)
+							{
+								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								{
+									$reftranslation = $this->translations["$client|$reftag|$name"];
+
+									if (array_key_exists("$client|$tag|$name", $this->translations))
+									{
+										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+									}
+									else
+									{
+										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+										$translation = new JObject(array('type' => 'library', 'tag' => $tag, 'client' => $client, 'storage' => 'global', 'filename' => $name, 'name' => $name, 'refpath' => $reftranslation->path, 'path' => $path, 'state' => 'unexisting', 'writable' => LocaliseHelper::isWritable($path), 'origin' => 'core'));
+										$this->translations["$client|$tag|$name"] = $translation;
+									}
+								}
+							}
+						}
+
 						if (preg_match("/^$reftag\.(lib.*)\.ini$/", $file, $matches))
 						{
 							$name   = $matches[1];


### PR DESCRIPTION
Some core ini files are not included in reference.
In the translations view, they display as not in reference for an already installed language.
When it is a new language, they do not even display
here is an example with the com_wrapper ini and sys.ini in administrator
Before:
![screen shot 2014-06-08 at 11 08 55](https://cloud.githubusercontent.com/assets/869724/3210868/9506b354-eeec-11e3-84e5-6414b61df4a2.png)

After:
![screen shot 2014-06-08 at 10 52 38](https://cloud.githubusercontent.com/assets/869724/3210835/716ef8ae-eeea-11e3-91b6-34a7b3bcbb07.png)

I have traced this issue to the existence or not of the component folder in the $client, the way the scans are done, i.e. if I add an empty com_wrapper folder in admin, then these files wou;d be included as reference automatically.

The PR forces them as reference.
