### PR TITLE
Adding xx-XX.finder_cli.ini as a translatable file in translations view

### DIFF
--- a/administrator/components/com_localise/models/translations.php
+++ b/administrator/components/com_localise/models/translations.php
@@ -255,6 +255,11 @@ class LocaliseModelTranslations extends JModelList
 									$translation->setProperties(array('type' => 'joomla', 'filename' => 'joomla', 'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA')));
 									$this->translations["$client|$tag|joomla"] = $translation;
 								}
+								elseif ($file == "$tag.finder_cli.ini")
+								{
+									$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
+									$this->translations["$client|$tag|$filename"] = $translation;
+								}
 								elseif ($prefix == "$tag.com" && preg_match("/$filter_type/", 'component'))
 								{
 									// Scan component ini file
@@ -362,7 +367,7 @@ class LocaliseModelTranslations extends JModelList
 					{
 						// Coping with Core files not considered as reference
 						if ($file == $reftag . '.com_messages.ini' || $file == $reftag . '.com_mailto.sys.ini'
-							|| $file == $reftag . '.com_wrapper.ini'|| $file == $reftag . '.com_wrapper.sys.ini')
+							|| $file == $reftag . '.com_wrapper.ini'|| $file == $reftag . '.com_wrapper.sys.ini' || $file == $reftag . '.finder_cli.ini')
 						{
 							$reftaglength = strlen($reftag);
 


### PR DESCRIPTION
The file will now be available in the Translations View for the Site client
![screen shot 2014-06-18 at 09 39 01](https://cloud.githubusercontent.com/assets/869724/3310836/b14466de-f6bb-11e3-8bfd-e36f8e954c6c.png)
