### PR TITLE
Throwing errors and preventing creating core pack if files missing.

### DIFF
--- a/administrator/components/com_localise/language/en-GB/en-GB.com_localise.ini
+++ b/administrator/components/com_localise/language/en-GB/en-GB.com_localise.ini
@@ -406,7 +406,9 @@ COM_LOCALISE_GROUP_DOWNLOADPACKAGE="Download Package"
 [Download Package]
 
 COM_LOCALISE_ERROR_DOWNLOADPACKAGE_UNEXISTING="Package %s does not exist"
+COM_LOCALISE_ERROR_NO_XML="The package can't be created because the %s %s does not exist in the target language"
 COM_LOCALISE_FIELDSET_DOWNLOADPACKAGE="Package download"
+COM_LOCALISE_FILE_NOT_TRANSLATED="<p>The file %s does not exist in the %s target language</p>"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_AUTHOR="Author"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_AUTHOR_DESC="Author desc"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_COPYRIGHT="Copyright"
@@ -419,7 +421,9 @@ COM_LOCALISE_LABEL_DOWNLOADPACKAGE_URL="URL"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_URL_DESC="URL desc"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_VERSION="Version"
 COM_LOCALISE_LABEL_DOWNLOADPACKAGE_VERSION_DESC="Version desc"
+COM_LOCALISE_MAINFILE_NOT_TRANSLATED="<p>The main file %s does not exist in the %s target language</p>"
 COM_LOCALISE_NOTICE_DOWNLOADPACKAGE_NOTSTANDALONE="Package %s not standalone"
+COM_LOCALISE_UNTRANSLATED="<strong>The package can't be created as one or multiple files do not exist in the target language</strong>"
 
 [Export]
 


### PR DESCRIPTION
Also creates a basic xx-XX.localise.php if absent.
This last one can be changed if/when we enable the creation of a custom localise.php in one of the views.
