### PR TITLE
Limiting language choice when creating packages

### DIFF
--- a/component/admin/helpers/localise.php
+++ b/component/admin/helpers/localise.php
@@ -149,11 +149,6 @@ abstract class LocaliseHelper
 			{
 				static::$origins['site'][$file] = $package->name;
 			}
-
-			foreach ($package->installation as $file)
-			{
-				static::$origins['installation'][$file] = $package->name;
-			}
 		}
 	}
 

--- a/component/admin/models/fields/corelanguage.php
+++ b/component/admin/models/fields/corelanguage.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package     Com_Localise
+ * @subpackage  models
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+jimport('joomla.filesystem.folder');
+
+/**
+ * Renders a list of all languages
+ * Use instead of the joomla library languages element, which only lists languages for one client
+ *
+ * @package     Extensions.Components
+ * @subpackage  Localise
+ *
+ * @since       1.0
+ */
+class JFormFieldCoreLanguage extends JFormField
+{
+	/**
+	 * The field type.
+	 *
+	 * @var    string
+	 */
+	protected $type = 'Corelanguage';
+
+	/**
+	 * Method to get the field input.
+	 *
+	 * @return  string    The field input.
+	 */
+	protected function getInput()
+	{
+		$attributes = '';
+
+		if ($v = (string) $this->element['onchange'])
+		{
+			$attributes .= ' onchange="' . $v . '"';
+		}
+
+		$params    = JComponentHelper::getParams('com_localise');
+		$reference = $params->get('reference', 'en-GB');
+		$admin     = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+		$site      = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+
+		$languages  = array_merge($admin, $site);
+		$attributes .= ' class="' . (string) $this->element['class'] . ($this->value == $reference ? ' iconlist-16-reference"' : '"');
+
+		foreach ($languages as $i => $language)
+		{
+			$languages[$i] = JArrayHelper::toObject($language);
+		}
+
+		JArrayHelper::sortObjects($languages, 'name');
+		$options = array();
+
+		foreach ($this->element->children() as $option)
+		{
+			$options[] = JHtml::_('select.option', $option->attributes('value'), JText::_(trim($option)), array('option.attr' => 'attributes', 'attr' => ''));
+		}
+
+		foreach ($languages as $language)
+		{
+			$options[] = JHtml::_(
+				'select.option',
+				$language->tag,
+				$language->name,
+				array(
+					'option.attr' => 'attributes',
+					'attr' => 'class="' . ($language->tag == $reference ? 'iconlist-16-reference" title="' . JText::_('COM_LOCALISE_TOOLTIP_FIELD_LANGUAGE_REFERENCE') . '"' : '"'
+					)
+				)
+			);
+		}
+
+		$return = JHtml::_('select.genericlist', $options, $this->name, array('id' => $this->id, 'list.select' => $this->value, 'option.attr' => 'attributes', 'list.attr' => $attributes));
+
+		return $return;
+	}
+}

--- a/component/admin/models/forms/package.xml
+++ b/component/admin/models/forms/package.xml
@@ -33,7 +33,7 @@
 		<field
 			id="language"
 			name="language"
-			type="language"
+			type="corelanguage"
 			label="COM_LOCALISE_LABEL_PACKAGE_LANGUAGE"
 			description="COM_LOCALISE_LABEL_PACKAGE_LANGUAGE_DESC"
 			required="true" />

--- a/component/admin/models/forms/packagefile.xml
+++ b/component/admin/models/forms/packagefile.xml
@@ -26,7 +26,7 @@
 		<field
 			id="language"
 			name="language"
-			type="language"
+			type="corelanguage"
 			label="COM_LOCALISE_LABEL_PACKAGE_LANGUAGE"
 			description="COM_LOCALISE_LABEL_PACKAGE_LANGUAGE_DESC"
 			required="true" />

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -302,25 +302,6 @@ class LocaliseModelPackage extends JModelForm
 				}
 
 				$package->installation = array();
-
-				if ($xml->installation)
-				{
-					foreach ($xml->installation->children() as $file)
-					{
-						$data = (string) $file->data();
-
-						if ($data)
-						{
-							$package->translations[] = "installation_$data";
-						}
-						else
-						{
-							$package->translations[] = "installation_joomla";
-						}
-
-						$package->installation[] = $data;
-					}
-				}
 			}
 			else
 			{
@@ -420,11 +401,6 @@ class LocaliseModelPackage extends JModelForm
 				{
 					$administrator[] = $matches[1];
 				}
-
-				if (preg_match('/^installation_(.*)$/', $translation, $matches))
-				{
-					$installation[] = $matches[1];
-				}
 			}
 
 			// Add the site language files
@@ -453,20 +429,6 @@ class LocaliseModelPackage extends JModelForm
 				}
 
 				$packageXml->appendChild($adminXml);
-			}
-
-			// Add the installation language files
-			if (count($installation))
-			{
-				$installXml = $dom->createElement('installation');
-
-				foreach ($installation as $translation)
-				{
-					$fileElement = $dom->createElement('filename', $translation . '.ini');
-					$installXml->appendChild($fileElement);
-				}
-
-				$packageXml->appendChild($installXml);
 			}
 
 			$dom->appendChild($packageXml);
@@ -504,7 +466,7 @@ class LocaliseModelPackage extends JModelForm
 			}
 		}
 
-		/*
+		/* @TODO Check ftp part
 		// Save the title and the description in the language file
 		$translation_path  = LocaliseHelper::findTranslationPath($client, JFactory::getLanguage()->getTag(), $manifest);
 		$translation_id    = LocaliseHelper::getFileId($translation_path);
@@ -632,11 +594,6 @@ class LocaliseModelPackage extends JModelForm
 			if (preg_match('/^administrator_(.*)$/', $translation, $matches))
 			{
 				$administrator[] = $matches[1];
-			}
-
-			if (preg_match('/^installation_(.*)$/', $translation, $matches))
-			{
-				$installation[] = $matches[1];
 			}
 		}
 
@@ -892,22 +849,6 @@ class LocaliseModelPackage extends JModelForm
 
 			$main_package_files[]= array('name'=>'admin_' . $data['language'] . '.zip','data' => JFile::read($admin_zip_path));
 		}
-
-		if (count($installation))
-		{
-			/*
-			 * ignore for now as language packages usually don't have language files for the installation area
-			$text .= "\t".'<installation>' . "\n";
-
-			foreach ($installation as $translation)
-			{
-				$text .= "\t\t".'<filename>' . $translation . '.ini</filename>' . "\n";
-			}
-
-			$text .= "\t".'</installation>' . "\n";
-			*/
-		}
-
 
 		$text .= "\t" . '</files>' . "\n";
 		if(!empty($data['serverurl'])){

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -300,8 +300,6 @@ class LocaliseModelPackage extends JModelForm
 						$package->site[] = $data;
 					}
 				}
-
-				$package->installation = array();
 			}
 			else
 			{

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -438,7 +438,7 @@ class LocaliseModelPackageFile extends JModelForm
 			}
 		}
 
-		/**
+		/** @TODO: Check ftp code
 		// Save the title and the description in the language file
 		$translation_path  = LocaliseHelper::findTranslationPath($client, JFactory::getLanguage()->getTag(), $manifest);
 		$translation_id    = LocaliseHelper::getFileId($translation_path);


### PR DESCRIPTION
Limiting language choice to existing core site and administrator xx-XX.xml when creating packages. Cleaning up 'installation' related code for package.php.

Before:
![screen shot 2014-06-21 at 07 10 39](https://cloud.githubusercontent.com/assets/869724/3347891/7728d158-f902-11e3-8fa1-8b0e6cd46086.png)

After
![screen shot 2014-06-21 at 07 08 25](https://cloud.githubusercontent.com/assets/869724/3347890/3251a10e-f902-11e3-8f87-b72f74ec97d7.png)
