### PR TITLE
Package Save: Can't check permissions when package name.xml is not yet created

### DIFF
--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -435,7 +435,7 @@ class LocaliseModelPackage extends JModelForm
 			$ftp = JClientHelper::getCredentials('ftp');
 
 			// Try to make the file writeable.
-			if (!$ftp['enabled'] && JPath::isOwner($path) && !JPath::setPermissions($path, '0644'))
+			if (JFile::exists($path) && !$ftp['enabled'] && JPath::isOwner($path) && !JPath::setPermissions($path, '0644'))
 			{
 				$this->setError(JText::sprintf('COM_LOCALISE_ERROR_PACKAGE_WRITABLE', $path));
 

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -410,7 +410,7 @@ class LocaliseModelPackageFile extends JModelForm
 			$ftp = JClientHelper::getCredentials('ftp');
 
 			// Try to make the file writeable.
-			if (!$ftp['enabled'] && JPath::isOwner($path) && !JPath::setPermissions($path, '0644'))
+			if (JFile::exists($path) && !$ftp['enabled'] && JPath::isOwner($path) && !JPath::setPermissions($path, '0644'))
 			{
 				$this->setError(JText::sprintf('COM_LOCALISE_ERROR_PACKAGE_WRITABLE', $path));
 


### PR DESCRIPTION
This PR corrects the "PHP Warning:  fileowner(): stat failed" when saving a new package
