### PR TITLE
ignore travis code sniff check in template files

### DIFF
--- a/.travis.xml
+++ b/.travis.xml
@@ -4,12 +4,14 @@
 	<property name="basedir" value="." />
 
 	<target name="travis" description="Generate codestyle report using PHP_CodeSniffer for output on Travis-CI">
+		<property name="phpcs-ignore" value="${basedir}/component/admin/views/*/tmpl/*" />
 		<exec executable="phpcs" passthru="true">
 			<arg line="-p" />
 			<arg line="-w" />
 			<arg value="--report=full"/>
 			<arg value="--extensions=php"/>
 			<arg value="--standard=${basedir}/.travis/coding-standards/Joomla/ruleset.xml"/>
+			<arg value="--ignore=${phpcs-ignore}"/>
 			<arg path="${basedir}/component"/>
 		</exec>
 	</target>


### PR DESCRIPTION
In pull #133 was removed this line https://github.com/joomla-projects/com_localise/pull/133/files#diff-2537849347c1077284ce7fc88878e4c5R6 witch was good.

But we still need to ask travis to ignore the /tmpl/ files when doing the PHPCS because we use inline PHP in templates instead of normal PHP.

After this pull travis should not be checking this https://travis-ci.org/joomla-projects/com_localise/jobs/28164657#L553 
