### PR TITLE
Refactor to use a PHP script for PHPCS on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ build/logs
 /tests/system/servers/configdef.php
 /tests/system/webdriver/tests/logs/
 
+# Composer
+composer.lock
+/vendor
+
 # Never ignore
 !.gitignore
 !index.html

--- a/.travis.xml
+++ b/.travis.xml
@@ -5,7 +5,7 @@
 
 	<target name="travis" description="Generate codestyle report using PHP_CodeSniffer for output on Travis-CI">
 		<property name="phpcs-ignore" value="${basedir}/component/admin/views/*/tmpl/*" />
-		<exec executable="phpcs" passthru="true">
+		<exec executable="phpcs">
 			<arg line="-p" />
 			<arg line="-w" />
 			<arg value="--report=full"/>

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ php:
   - 5.5
 
 before_script:
-  - pear install PHP_CodeSniffer-1.5.3
-  - pear channel-discover pear.phing.info
-  - pear install phing/phing
-  - phpenv rehash
+  - composer install
 
 script:
   - find ./component -name '*.php' -exec php -l {} \;
-  - phing -f .travis.xml
+  - php .travis/phpcs.php

--- a/.travis/phpcs.php
+++ b/.travis/phpcs.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Command line script for executing PHPCS during a Travis build.
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Only run on the CLI SAPI
+(php_sapi_name() == 'cli' ?: die('CLI only'));
+
+// Script defines
+define('REPO_BASE', dirname(__DIR__));
+
+// Require Composer autoloader
+if (!file_exists(REPO_BASE . '/vendor/autoload.php'))
+{
+	fwrite(STDOUT, "\033[37;41mThis script requires Composer to be set up, please run 'composer install' first.\033[0m\n");
+}
+
+require REPO_BASE . '/vendor/autoload.php';
+
+// Welcome message
+fwrite(STDOUT, "\033[32;1mInitializing PHP_CodeSniffer checks.\033[0m\n");
+
+// Build the options for the sniffer
+$options = array(
+	'files'        => array(REPO_BASE . '/component'),
+    'standard'     => array(__DIR__ . '/coding-standards/Joomla'),
+    'ignored'      => array(REPO_BASE . '/component/admin/views/*/tmpl/*'),
+    'showProgress' => true
+);
+
+// Instantiate the sniffer
+$phpcs = new PHP_CodeSniffer_CLI;
+
+// Ensure PHPCS can run, will exit if requirements aren't met
+$phpcs->checkRequirements();
+
+// Run the sniffs
+$numErrors = $phpcs->process($options);
+
+// If there were errors, output the number and exit the app with a fail code
+if ($numErrors)
+{
+	fwrite(STDOUT, sprintf("\033[37;41mThere were %d issues detected.\033[0m\n", $numErrors));
+	exit(1);
+}
+else
+{
+	fwrite(STDOUT, "\033[32;1mThere were no issues detected.\033[0m\n");
+	exit(0);
+}

--- a/.travis/phpcs.php
+++ b/.travis/phpcs.php
@@ -26,9 +26,9 @@ fwrite(STDOUT, "\033[32;1mInitializing PHP_CodeSniffer checks.\033[0m\n");
 // Build the options for the sniffer
 $options = array(
 	'files'        => array(REPO_BASE . '/component'),
-    'standard'     => array(__DIR__ . '/coding-standards/Joomla'),
-    'ignored'      => array(REPO_BASE . '/component/admin/views/*/tmpl/*'),
-    'showProgress' => true
+	'standard'     => array(__DIR__ . '/coding-standards/Joomla'),
+	'ignored'      => array(REPO_BASE . '/component/admin/views/*/tmpl/*'),
+	'showProgress' => true
 );
 
 // Instantiate the sniffer

--- a/README.md
+++ b/README.md
@@ -33,7 +33,21 @@ The following image details the actors and use cases of the application:
 * New features tasks: https://github.com/joomla-projects/com_localise/issues?milestone=3&state=open
 
 # Tests
-See testing documentation at [test readme](./tests/system/readme.md)
+
+## System Tests
+See testing documentation for the system tests at [tests/system/readme.md](./tests/system/readme.md)
+
+## PHP_CodeSniffer
+All PHP files except for layout files (located in a `/tmpl` directory) should be formatted to follow the [Joomla! Coding Standards](http://joomla.github.io/coding-standards/).  These are validated by using PHP_CodeSniffer.  You can run the PHP_CodeSniffer in one of the following manners:
+
+* Using Ant:
+    * From the command line, you can use Ant by running `ant -f .travis.xml` from the repository root
+* Using Phing:
+    * From the command line, you can use Phing by running `phing -f .travis.xml` from the repository root
+* PHP Script:
+    * From the command line, you can run a custom PHP script by running `php .travis/phpcs.php` from the repository root
+    * To use this script, you must have [Composer](https://getcomposer.org/) installed on your system and must run the `composer install` command from the repository root
+    * This is the script utilized by Travis-CI
 
 # Requirements
 Joomla 3.3 or above is needed to run this component.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+	"name"       : "joomla/com_localise",
+	"description": "forked version of the original com_localise for experimental purposes",
+	"license"    : "GPL-2.0+",
+	"require"    : {
+		"php": ">=5.3.10"
+	},
+	"require-dev": {
+		"squizlabs/php_codesniffer": "1.*"
+	}
+}


### PR DESCRIPTION
PHPCS does not cause a Travis build to fail when there are codestyle errors detected, making a build appear to pass all tests.  To get around this, a custom script must be used to run PHPCS and flag the build script as failed.

This will use Composer to install PHPCS in place of the PEAR dependencies on PHPCS and Phing in the Travis environment.  The documentation is also updated to reflect that PHPCS can be run using Ant, Phing, or this PHP script.
