### PR TITLE
Limiting extension package choice to non-core files

### DIFF
--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -49,13 +49,13 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 		$xml = simplexml_load_file(JPATH_ROOT . '/media/com_localise/packages/core.xml');
 		$coreadminfiles	= (array) $xml->administrator->children();
 		$coresitefiles	= (array) $xml->site->children();
-		
+
 		$coresitefiles	= $coresitefiles['filename'];
 		$coreadminfiles	= $coreadminfiles['filename'];
 
 		$coreadminfiles	= self::suffix_array_values($coreadminfiles, '.ini');
 		$coresitefiles	= self::suffix_array_values($coresitefiles, '.ini');
-		
+
 		$package = (string) $this->element['package'];
 		$groups  = array('Site' => array(), 'Administrator' => array());
 
@@ -85,7 +85,7 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 							$value    = $key;
 							$origin   = LocaliseHelper::getOrigin($key, strtolower($client));
 							$disabled = $origin != $package && $origin != '_thirdparty';
-							
+
 							$groups[$client][$key] = JHtml::_('select.option', strtolower($client) . '_' . $key, $value, 'value', 'text', false);
 						}
 					}
@@ -97,8 +97,8 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 
 		foreach ($scans as $scan)
 		{
-			
-			
+
+
 			$prefix     = $scan['prefix'];
 			$suffix     = $scan['suffix'];
 			$type       = $scan['type'];
@@ -146,7 +146,7 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 
 		return $groups;
 	}
-	
+
 	/**
 	 * Method to add a suffix to an array.
 	 *
@@ -154,22 +154,22 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 	 */
 	public static function suffix_array_values($array, $suffix = '')
 	{
-    	if (!is_array($array))
-    	{
-       	 return false;
-        }
-     
-    	// suffix the values and respect the keys
-    	foreach ($array as $key => $value)
-    	{
+		if (!is_array($array))
+		{
+			return false;
+		}
+
+		// Suffix the values and respect the keys
+		foreach ($array as $key => $value)
+		{
 			if (!is_string($value))
 			{
-            	continue;
+				continue;
 			}
-             
-        	$array[$key] = $value.$suffix;
-    	}
-    	
-    	return $array;
-    }
+
+			$array[$key] = $value.$suffix;
+		}
+
+		return $array;
+	}
 }

--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -97,8 +97,6 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 
 		foreach ($scans as $scan)
 		{
-
-
 			$prefix     = $scan['prefix'];
 			$suffix     = $scan['suffix'];
 			$type       = $scan['type'];
@@ -126,9 +124,13 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 								$origin   = LocaliseHelper::getOrigin("$prefix$extension$suffix", strtolower($client));
 								$disabled = $origin != $package && $origin != '_thirdparty';
 
-								// @ Todo: $disabled prevents choosing some core files when creating package.
-								//$groups[$client]["$prefix$extension$suffix"] = JHtml::_('select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', $disabled);
-								$groups[$client]["$prefix$extension$suffix"] = JHtml::_('select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', false);
+							/* @ Todo: $disabled prevents choosing some core files when creating package.
+							 $groups[$client]["$prefix$extension$suffix"] = JHtml::_(
+							'select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', $disabled);
+							*/
+							$groups[$client]["$prefix$extension$suffix"] = JHtml::_(
+									'select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', false
+							);
 							}
 						}
 					}
@@ -150,7 +152,10 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 	/**
 	 * Method to add a suffix to an array.
 	 *
-	 * @return  array    Array of strings suffixed
+	 * @param   array   $array   An array of core files.
+	 * @param   string  $suffix  The suffix to add to each file.
+	 *
+	 * @return  array   The modified array
 	 */
 	public static function suffix_array_values($array, $suffix = '')
 	{
@@ -167,7 +172,7 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 				continue;
 			}
 
-			$array[$key] = $value.$suffix;
+			$array[$key] = $value . $suffix;
 		}
 
 		return $array;

--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -142,7 +142,7 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 		{
 			if (count($groups[$client]) == 0)
 			{
-				$groups[$client][] = JHtml::_('select.option', '', ' - No translation - ', 'value', 'text', true);
+				$groups[$client][] = JHtml::_('select.option', '',  JText::_('COM_LOCALISE_NOTRANSLATION'), 'value', 'text', true);
 			}
 			else
 			{

--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * @package     Com_Localise
+ * @subpackage  models
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+jimport('joomla.html.html');
+jimport('joomla.filesystem.folder');
+JFormHelper::loadFieldClass('groupedlist');
+
+/**
+ * Form Field ExtensionTranslations class.
+ *
+ * @package     Extensions.Components
+ * @subpackage  Localise
+ *
+ * @since       1.0
+ */
+class JFormFieldExtensionTranslations extends JFormFieldGroupedList
+{
+	/**
+	 * The field type.
+	 *
+	 * @var    string
+	 */
+	protected $type = 'ExtensionTranslations';
+
+	/**
+	 * Method to get a list of options for a list input.
+	 *
+	 * @return  array    An array of JHtml options.
+	 */
+	protected function getGroups()
+	{
+		// Remove '.ini' from values
+		if (is_array($this->value))
+		{
+			foreach ($this->value as $key => $val)
+			{
+				$this->value[$key] = substr($val, 0, -4);
+			}
+		}
+
+		$xml = simplexml_load_file(JPATH_ROOT . '/media/com_localise/packages/core.xml');
+		$coreadminfiles	= (array) $xml->administrator->children();
+		$coresitefiles	= (array) $xml->site->children();
+		
+		$coresitefiles	= $coresitefiles['filename'];
+		$coreadminfiles	= $coreadminfiles['filename'];
+
+		$coreadminfiles	= self::suffix_array_values($coreadminfiles, '.ini');
+		$coresitefiles	= self::suffix_array_values($coresitefiles, '.ini');
+		
+		$package = (string) $this->element['package'];
+		$groups  = array('Site' => array(), 'Administrator' => array());
+
+		foreach (array('Site', 'Administrator') as $client)
+		{
+			$path = constant('LOCALISEPATH_' . strtoupper($client)) . '/language';
+
+			if (JFolder::exists($path))
+			{
+				$tags = JFolder::folders($path, '.', false, false, array('overrides', '.svn', 'CVS', '.DS_Store', '__MACOSX'));
+
+				if ($tags)
+				{
+					foreach ($tags as $tag)
+					{
+						$files = JFolder::files("$path/$tag", ".ini$");
+
+						$files = str_replace($tag . '.', '', $files);
+						$files = array_diff($files, $coreadminfiles);
+						$files = array_diff($files, $coresitefiles);
+						$files = array_diff($files, array('ini'));
+
+						foreach ($files as $file)
+						{
+							$basename = $file;
+							$key      = substr($basename, 0, strlen($basename) - 4);
+							$value    = $key;
+							$origin   = LocaliseHelper::getOrigin($key, strtolower($client));
+							$disabled = $origin != $package && $origin != '_thirdparty';
+							
+							$groups[$client][$key] = JHtml::_('select.option', strtolower($client) . '_' . $key, $value, 'value', 'text', false);
+						}
+					}
+				}
+			}
+		}
+
+		$scans = LocaliseHelper::getScans();
+
+		foreach ($scans as $scan)
+		{
+			
+			
+			$prefix     = $scan['prefix'];
+			$suffix     = $scan['suffix'];
+			$type       = $scan['type'];
+			$client     = ucfirst($scan['client']);
+			$path       = $scan['path'];
+			$folder     = $scan['folder'];
+			$extensions = JFolder::folders($path);
+
+			foreach ($extensions as $extension)
+			{
+				// Take off core extensions containing a language folder
+				if ($extension != ('mod_version' || 'mod_multilangstatus' || 'tpl_beez' || 'tpl_protostar' || 'tpl_hathor' || 'tpl_isis'))
+				{
+					if (JFolder::exists("$path$extension$folder/language"))
+					{
+						// Scan extensions folder
+						$tags = JFolder::folders("$path$extension$folder/language");
+
+						foreach ($tags as $tag)
+						{
+							$file = "$path$extension$folder/language/$tag/$tag.$prefix$extension$suffix.ini";
+
+							if (JFile::exists($file))
+							{
+								$origin   = LocaliseHelper::getOrigin("$prefix$extension$suffix", strtolower($client));
+								$disabled = $origin != $package && $origin != '_thirdparty';
+
+								// @ Todo: $disabled prevents choosing some core files when creating package.
+								//$groups[$client]["$prefix$extension$suffix"] = JHtml::_('select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', $disabled);
+								$groups[$client]["$prefix$extension$suffix"] = JHtml::_('select.option', strtolower($client) . '_' . "$prefix$extension$suffix", "$prefix$extension$suffix", 'value', 'text', false);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		foreach ($groups as $client => $extensions)
+		{
+			JArrayHelper::sortObjects($groups[$client], 'text');
+		}
+
+		// Merge any additional options in the XML definition.
+		$groups = array_merge(parent::getGroups(), $groups);
+
+		return $groups;
+	}
+	
+	/**
+	 * Method to add a suffix to an array.
+	 *
+	 * @return  array    Array of strings suffixed
+	 */
+	public static function suffix_array_values($array, $suffix = '')
+	{
+    	if (!is_array($array))
+    	{
+       	 return false;
+        }
+     
+    	// suffix the values and respect the keys
+    	foreach ($array as $key => $value)
+    	{
+			if (!is_string($value))
+			{
+            	continue;
+			}
+             
+        	$array[$key] = $value.$suffix;
+    	}
+    	
+    	return $array;
+    }
+}

--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -140,7 +140,14 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 
 		foreach ($groups as $client => $extensions)
 		{
-			JArrayHelper::sortObjects($groups[$client], 'text');
+			if (count($groups[$client]) == 0)
+			{
+				$groups[$client][] = JHtml::_('select.option', '', ' - No translation - ', 'value', 'text', true);
+			}
+			else
+			{
+				JArrayHelper::sortObjects($groups[$client], 'text');
+			}
 		}
 
 		// Merge any additional options in the XML definition.

--- a/component/admin/models/forms/packagefile.xml
+++ b/component/admin/models/forms/packagefile.xml
@@ -82,7 +82,7 @@
 		<field
 			id="translations"
 			name="translations"
-			type="translations"
+			type="extensiontranslations"
 			label="COM_LOCALISE_LABEL_PACKAGE_TRANSLATIONS"
 			description="COM_LOCALISE_LABEL_PACKAGE_TRANSLATIONS_DESC"
 			multiple="true"


### PR DESCRIPTION
Partly solving https://github.com/joomla-projects/com_localise/issues/126 as no chosen.
When creating a new Extension package, the choice will not include core files.
We will get for example:
![screen shot 2014-06-30 at 17 08 56](https://cloud.githubusercontent.com/assets/869724/3431208/87b0c89c-0068-11e4-9d5e-bd0ee23933e0.png)
