### PR TITLE
Various corrections for packages: readonly and translation

### DIFF
--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -114,12 +114,6 @@ class LocaliseModelPackage extends JModelForm
 
 		$form->setFieldAttribute('translations', 'package', $name, 'translations');
 
-		if (!empty($id))
-		{
-			$form->setFieldAttribute('name', 'readonly', 'true');
-			$form->setFieldAttribute('name', 'class', 'readonly');
-		}
-
 		// Check for an error.
 		if (JError::isError($form))
 		{
@@ -148,8 +142,6 @@ class LocaliseModelPackage extends JModelForm
 		if (empty($data))
 		{
 			$data = $this->getItem();
-			$data->title       = JText::_($data->title);
-			$data->description = JText::_($data->description);
 		}
 
 		return $data;

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -114,12 +114,6 @@ class LocaliseModelPackageFile extends JModelForm
 
 		$form->setFieldAttribute('translations', 'packagefile', $name, 'translations');
 
-		if (!empty($id))
-		{
-			$form->setFieldAttribute('name', 'readonly', 'true');
-			$form->setFieldAttribute('name', 'class', 'readonly');
-		}
-
 		// Check for an error.
 		if (JError::isError($form))
 		{
@@ -148,7 +142,6 @@ class LocaliseModelPackageFile extends JModelForm
 		if (empty($data))
 		{
 			$data = $this->getItem();
-			$data->description = JText::_($data->description);
 		}
 
 		return $data;


### PR DESCRIPTION
To prepare Save and Copy  future implementation for packages, this PR takes off the Readonly when editing an already saved package.
Also it gets rid of the translation of the Title, Name and Description as we do not create anymore specific package inis.
(also, description is anyway a CDATA)

we should now get (no more ?? -when debug lang is ON- and no more greyed field):
![screen shot 2014-07-03 at 11 13 28](https://cloud.githubusercontent.com/assets/869724/3467547/863bd386-0292-11e4-840f-5a720fc8e3e7.png)
