### PR TITLE
Fix [xmlproperty] Unable to find property file

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -24,7 +24,7 @@
 
 	<!-- Load extension version property in XML file -->
 	<xmlproperty
-			file="${project.dir}/localise.xml"
+			file="${project.basedir}/../localise.xml"
 			prefix="extensionDetails"
 			keepRoot="false" />
 	<property


### PR DESCRIPTION
This should fix:

Buildfile: /Users/mac/joomlatrunk/upstream_localise/build/build.xml
[xmlproperty] Loading /Applications/MAMP/bin/php/php5.4.4/bin/../localise.xml
[xmlproperty] Unable to find property file: /Applications/MAMP/bin/php/php5.4.4/bin/../localise.xml... skipped
[PHP Error] Argument 1 passed to PropertyTask::resolveAllProperties() must be an instance of Properties, null given, called in /Applications/MAMP/bin/php/php5.4.4/lib/php/phing/tasks/system/PropertyTask.php on line 280 and defined [line 343 of /Applications/MAMP/bin/php/php5.4.4/lib/php/phing/tasks/system/PropertyTask.php]

Caused by: https://github.com/joomla-projects/com_localise/commit/9e80f02b6d5af4a97ede113530a1747703da7f0e
