### PR TITLE
[fix] Build system. Fixes #181

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 rm -rf packaging && mkdir packaging
 rm -rf packages && mkdir packages
-cp -r ../component/admin packaging/admin
-cp -r ../media/ packaging/media
-mv packaging/admin/localise.xml packaging/localise.xml
-mv packaging/admin/script.php packaging/script.php
+cp -r ../component packaging
+cp -r ../media/ packaging
+cp ../localise.xml packaging
+cp ../install.php packaging
 cd packaging
-zip -r ../packages/com_localise.zip admin/ media/ localise.xml script.php
+zip -r ../packages/com_localise.zip component/ media/ localise.xml install.php

--- a/build/build.xml
+++ b/build/build.xml
@@ -13,7 +13,7 @@
 	<!-- Name of extension -->
 	<property name="extension" value="${phing.project.name}" override="true"/>
 
-	<property name="project.dir" value="${application.startdir}/.." override="true"/>
+	<property name="project.dir" value="${project.basedir}/.." override="true"/>
 
 	<!-- Extension folders -->
 	<property name="component.dir" value="${project.dir}/component" override="true"/>

--- a/build/copier.xml
+++ b/build/copier.xml
@@ -15,19 +15,28 @@
 <project name="localise" default="copy" basedir=".">
 
 	<target name="init" >
+		<property name="src" value="${application.startdir}" />
+		<!-- Check if build is called inside the build folder -->
 		<if>
 			<not>
-				<available file="build.properties" />
+				<available file="${src}/localise.xml" />
+			</not>
+			<then>
+				<property name="src" value="${project.basedir}/.." override="true"/>
+			</then>
+		</if>
+		<if>
+			<not>
+				<available file="${src}/build.properties" />
 			</not>
 			<then>
 				<fail message="The file build.properties does not exists." />
 			</then>
 			<else>
-				<property file="build.properties"  override="true"/>
+				<property file="${src}/build.properties"  override="true"/>
 				<echo message="build.properties File included successfully." />
 			</else>
 		</if>
-		<property name="src" value="${application.startdir}/.." />
 	</target>
 
 	<target name="prepare" >


### PR DESCRIPTION
This fixes build calls from outside the build folder. Now we have:
## Build: Create zip extension package
### From extension root

``` bash
phing -f build/build.xml
```
### From build folder

``` bash
cd build
phing
```
### From build folder using bash script

``` bash
cd build
./build.sh
```
## Build: update test site
### From extension root

You have to duplicate `build/build.properties.dist` to the extension root `build.properties` and then adjust the content to your test site path like:

``` ini
# Properties files are configuration files used by PHING scripts containing:
# key=value

# Testing Joomla site localhost folder used by build.xml
joomla.dir=/var/www/jcms3x
```

Then you can update the test site anytime with:

``` bash
phing -f build/copier.xml
```
### From build folder

You have to duplicate `build/build.properties.dist` to `build/build.properties` and then adjust the content to your test site path like:

``` ini
# Properties files are configuration files used by PHING scripts containing:
# key=value

# Testing Joomla site localhost folder used by build.xml
joomla.dir=/var/www/jcms3x
```

Then you can update the test site anytime with:

``` bash
cd build
phing -f copier.xml
```
