### PR TITLE
Add travis PHP Parse Error checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - composer install
 
 script:
-  - find ./component -name '*.php' -exec php -l {} \;
+  - php .travis/phppec.php administrator/
   - php .travis/phpcs.php
   - php .travis/phpmd.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - composer install
 
 script:
-  - php .travis/phppec.php administrator/
+  - php .travis/phppec.php component/
   - php .travis/phpcs.php
   - php .travis/phpmd.php

--- a/.travis/phppec.php
+++ b/.travis/phppec.php
@@ -32,7 +32,7 @@ for($i=1;$i < count($argv);$i++)
 
     if (!file_exists($folderToCheck))
     {
-        fwrite(STDOUT, "\033[32;1mFolder" . $argv[$i] . " does not exist\033[0m\n");
+        fwrite(STDOUT, "\033[32;1mFolder: " . $argv[$i] . " does not exist\033[0m\n");
         continue;
     }
 

--- a/.travis/phppec.php
+++ b/.travis/phppec.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Command line script for detecting PHP Parse Errors.
+ *
+ * This CLI is used instead normal travis.yml execution to avoid error in travis build when
+ * PHPMD exits with 2.
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Only run on the CLI SAPI
+(php_sapi_name() == 'cli' ?: die('CLI only'));
+
+// Script defines
+define('REPO_BASE', dirname(__DIR__));
+
+// Welcome message
+fwrite(STDOUT, "\033[32;1mInitializing PHP Parse Error checks.\033[0m\n");
+
+if (2 > count($argv))
+{
+    fwrite(STDOUT, "\033[32;1mPlease add path to check for PHP Parse Errors.\033[0m\n");
+    exit(1);
+}
+
+$errors = 0;
+
+for($i=1;$i < count($argv);$i++)
+{
+    $folderToCheck = REPO_BASE . '/' .$argv[$i];
+
+    if (!file_exists($folderToCheck))
+    {
+        fwrite(STDOUT, "\033[32;1mFolder" . $argv[$i] . " does not exist\033[0m\n");
+        continue;
+    }
+
+    fwrite(STDOUT, "\033[32;1mChecking errors at: " . $argv[$i] . "\033[0m\n");
+    $parseErrors = shell_exec('find ' . $folderToCheck .' -name "*.php" -exec php -l {} \; | grep "Parse error";');
+
+    if ($parseErrors)
+    {
+        $errors = 1;
+        fwrite(STDOUT, $parseErrors);
+    }
+}
+
+if ($errors)
+{
+    exit(1);
+}
+
+exit(0);


### PR DESCRIPTION
This parse error checker is a PHP script that checks the existence of PHP parse Errors in Travis:
https://github.com/redCOMPONENT-COM/redITEM2/blob/develop/.travis/phpparseerrorchecker.php

Initially we used 

``` sh
- find ./component -name '*.php' -exec php -l {} \;
```

But it generates an endless log in travis that is not very much useful:

``` sh
$ find ./component -name '*.php' -exec php -l {} \;
No syntax errors detected in ./administrator/component//views/categories/tmpl/elements.php
No syntax errors detected in ./component/admin/views/categories/tmpl/default.php
No syntax errors detected in ./component/admin/views/categories/view.html.php
...
```

After that we thought on:

``` sh
- find ./component -name '*.php' -exec php -l {} \; | grep "Parse error";
```

But GREP exits with **exit(0)** if founds a "parse error" and with **exit(1)** if it doesn't found, witch is exactly the opposite that we need to make Travis fail when there is a Parse error.

So the proposal is /.travis/phppec.php takes control of the exit code and makes Travis fail if there is a Parse error found.

@mbabker, @phproberto, @wilsonge If you like this proposal we can add it too to the Joomla-cms repository
