### PR TITLE
Proposing core translations only when a xx-XX.xml file is present in the xx-XX folder

### DIFF
--- a/component/admin/models/forms/translations.xml
+++ b/component/admin/models/forms/translations.xml
@@ -48,6 +48,9 @@
 				onchange="this.form.submit()">
 				<option value="">COM_LOCALISE_OPTION_TRANSLATIONS_TYPE_SELECT</option>
 			</field>
+			<field name="spacer_client" type="spacer" class="text"
+				label="COM_LOCALISE_OPTION_CLIENT_SELECT"
+			/>
 			<field
 				id="client"
 				name="client"
@@ -55,8 +58,10 @@
 				class="span12 small"
 				hidden="true"
 				onchange="this.form.submit()">
-				<option value="">COM_LOCALISE_OPTION_CLIENT_SELECT</option>
 			</field>
+			<field name="spacer_lang" type="spacer" class="text"
+				label="COM_LOCALISE_OPTION_LANGUAGE_SELECT"
+			/>
 			<field
 				id="tag"
 				name="tag"
@@ -65,7 +70,6 @@
 				client="site"
 				hidden="true"
 				onchange="this.form.submit()">
-				<option value="">COM_LOCALISE_OPTION_LANGUAGE_SELECT</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -249,93 +249,96 @@ class LocaliseModelTranslations extends JModelList
 
 					foreach ($tags as $tag)
 					{
-						// For all selected tags
-						$files = JFolder::files("$path/$tag", "$filter_search.*\.ini$");
-
-						foreach ($files as $file)
+						if (JFile::exists($path . '/' . $tag . '/' . $tag . '.xml'))
 						{
-							$filename = substr($file, 1 + strlen($tag));
+							// For all selected tags
+							$files = JFolder::files("$path/$tag", "$filter_search.*\.ini$");
 
-							if ($filename == 'ini')
+							foreach ($files as $file)
 							{
-								$filename = '';
-							}
-							else
-							{
-								$filename = substr($filename, 0, strlen($filename) - 4);
-							}
+								$filename = substr($file, 1 + strlen($tag));
 
-							$origin = LocaliseHelper::getOrigin($filename, $client);
+								if ($filename == 'ini')
+								{
+									$filename = '';
+								}
+								else
+								{
+									$filename = substr($filename, 0, strlen($filename) - 4);
+								}
 
-							if (preg_match("/$filter_origin/", $origin))
-							{
-								$prefix = substr($file, 0, 4 + strlen($tag));
+								$origin = LocaliseHelper::getOrigin($filename, $client);
 
-								$translation = new JObject(
-									array(
-										'tag' => $tag,
-										'client' => $client,
-										'storage' => 'global',
-										'refpath' => null,
-										'path' => "$path/$tag/$file",
-										'state' => $tag == $reftag ? 'inlanguage' : 'notinreference',
-										'writable' => LocaliseHelper::isWritable("$path/$tag/$file"),
-										'origin' => $origin
-									)
-								);
+								if (preg_match("/$filter_origin/", $origin))
+								{
+									$prefix = substr($file, 0, 4 + strlen($tag));
 
-								if ($file == "$tag.ini" && preg_match("/$filter_type/", 'joomla'))
-								{
-									// Scan joomla ini file
-									$translation->setProperties(array('type' => 'joomla', 'filename' => 'joomla', 'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA')));
-									$this->translations["$client|$tag|joomla"] = $translation;
-								}
-								elseif ($file == "$tag.finder_cli.ini")
-								{
-									$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.com" && preg_match("/$filter_type/", 'component'))
-								{
-									// Scan component ini file
-									$translation->setProperties(array('type' => 'component', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.mod" && preg_match("/$filter_type/", 'module'))
-								{
-									// Scan module ini file
-									$translation->setProperties(array('type' => 'module', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.tpl" && preg_match("/$filter_type/", 'template'))
-								{
-									// Scan template ini file
-									$translation->setProperties(array('type' => 'template', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.plg" && preg_match("/$filter_type/", 'plugin'))
-								{
-									// Scan plugin ini file
-									$translation->setProperties(array('type' => 'plugin', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.pkg" && preg_match("/$filter_type/", 'package'))
-								{
-									// Scan package ini file
-									$translation->setProperties(array('type' => 'package', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.lib" && preg_match("/$filter_type/", 'library'))
-								{
-									// Scan library ini file
-									$translation->setProperties(array('type' => 'library', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.fil" && preg_match("/$filter_type/", 'file'))
-								{
-									// Scan files ini file
-									$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
+									$translation = new JObject(
+										array(
+											'tag' => $tag,
+											'client' => $client,
+											'storage' => 'global',
+											'refpath' => null,
+											'path' => "$path/$tag/$file",
+											'state' => $tag == $reftag ? 'inlanguage' : 'notinreference',
+											'writable' => LocaliseHelper::isWritable("$path/$tag/$file"),
+											'origin' => $origin
+										)
+									);
+
+									if ($file == "$tag.ini" && preg_match("/$filter_type/", 'joomla'))
+									{
+										// Scan joomla ini file
+										$translation->setProperties(array('type' => 'joomla', 'filename' => 'joomla', 'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA')));
+										$this->translations["$client|$tag|joomla"] = $translation;
+									}
+									elseif ($file == "$tag.finder_cli.ini")
+									{
+										$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.com" && preg_match("/$filter_type/", 'component'))
+									{
+										// Scan component ini file
+										$translation->setProperties(array('type' => 'component', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.mod" && preg_match("/$filter_type/", 'module'))
+									{
+										// Scan module ini file
+										$translation->setProperties(array('type' => 'module', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.tpl" && preg_match("/$filter_type/", 'template'))
+									{
+										// Scan template ini file
+										$translation->setProperties(array('type' => 'template', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.plg" && preg_match("/$filter_type/", 'plugin'))
+									{
+										// Scan plugin ini file
+										$translation->setProperties(array('type' => 'plugin', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.pkg" && preg_match("/$filter_type/", 'package'))
+									{
+										// Scan package ini file
+										$translation->setProperties(array('type' => 'package', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.lib" && preg_match("/$filter_type/", 'library'))
+									{
+										// Scan library ini file
+										$translation->setProperties(array('type' => 'library', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.fil" && preg_match("/$filter_type/", 'file'))
+									{
+										// Scan files ini file
+										$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
 								}
 							}
 						}
@@ -379,36 +382,40 @@ class LocaliseModelTranslations extends JModelList
 
 				foreach ($tags as $tag)
 				{
-					if (array_key_exists("$client|$reftag|joomla", $this->translations))
+
+					if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 					{
-						$reftranslation = $this->translations["$client|$reftag|joomla"];
-
-						if (array_key_exists("$client|$tag|joomla", $this->translations))
+						if (array_key_exists("$client|$reftag|joomla", $this->translations))
 						{
-							$this->translations["$client|$tag|joomla"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-						}
-						elseif ($filter_storage != 'local')
-						{
-							$origin = LocaliseHelper::getOrigin("", $client);
+							$reftranslation = $this->translations["$client|$reftag|joomla"];
 
-							$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
+							if (array_key_exists("$client|$tag|joomla", $this->translations))
+							{
+								$this->translations["$client|$tag|joomla"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+							}
+							elseif ($filter_storage != 'local')
+							{
+								$origin = LocaliseHelper::getOrigin("", $client);
 
-							$translation = new JObject(
-								array(
-									'type' => 'joomla',
-									'tag' => $tag,
-									'client' => $client,
-									'storage' => 'global',
-									'filename' => 'joomla',
-									'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA'),
-									'refpath' => $reftranslation->path,
-									'path' => $path,
-									'state' => 'unexisting',
-									'writable' => LocaliseHelper::isWritable($path),
-									'origin' => $origin
-								)
-							);
-							$this->translations["$client|$tag|joomla"] = $translation;
+								$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
+
+								$translation = new JObject(
+									array(
+										'type' => 'joomla',
+										'tag' => $tag,
+										'client' => $client,
+										'storage' => 'global',
+										'filename' => 'joomla',
+										'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA'),
+										'refpath' => $reftranslation->path,
+										'path' => $path,
+										'state' => 'unexisting',
+										'writable' => LocaliseHelper::isWritable($path),
+										'origin' => $origin
+									)
+								);
+								$this->translations["$client|$tag|joomla"] = $translation;
+							}
 						}
 					}
 				}
@@ -432,33 +439,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'library',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => 'core'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'library',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => 'core'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -471,33 +481,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'library',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => '_thirdparty'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'library',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => '_thirdparty'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -509,33 +522,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'package',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => '_thirdparty'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'package',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => '_thirdparty'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -614,31 +630,34 @@ class LocaliseModelTranslations extends JModelList
 					{
 						$origin = LocaliseHelper::getOrigin("$prefix$extension$suffix", $client);
 
-						if (array_key_exists("$client|$tag|$prefix$extension$suffix", $this->translations))
+						if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 						{
-							$this
-								->translations["$client|$tag|$prefix$extension$suffix"]
-								->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-						}
-						elseif ($filter_storage != 'local' && ($filter_origin == '' || $filter_origin == $origin))
-						{
-							$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$prefix$extension$suffix.ini";
-							$translation = new JObject(
-								array(
-									'type' => $type,
-									'tag' => $tag,
-									'client' => $client,
-									'storage' => 'global',
-									'filename' => "$prefix$extension$suffix",
-									'name' => "$prefix$extension$suffix",
-									'refpath' => $reftranslation->path,
-									'path' => $path, 'state' => 'unexisting',
-									'writable' => LocaliseHelper::isWritable($path),
-									'origin' => $origin
-								)
-							);
+							if (array_key_exists("$client|$tag|$prefix$extension$suffix", $this->translations))
+							{
+								$this
+									->translations["$client|$tag|$prefix$extension$suffix"]
+									->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+							}
+							elseif ($filter_storage != 'local' && ($filter_origin == '' || $filter_origin == $origin))
+							{
+								$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$prefix$extension$suffix.ini";
+								$translation = new JObject(
+									array(
+										'type' => $type,
+										'tag' => $tag,
+										'client' => $client,
+										'storage' => 'global',
+										'filename' => "$prefix$extension$suffix",
+										'name' => "$prefix$extension$suffix",
+										'refpath' => $reftranslation->path,
+										'path' => $path, 'state' => 'unexisting',
+										'writable' => LocaliseHelper::isWritable($path),
+										'origin' => $origin
+									)
+								);
 
-							$this->translations["$client|$tag|$prefix$extension$suffix"] = $translation;
+								$this->translations["$client|$tag|$prefix$extension$suffix"] = $translation;
+							}
 						}
 					}
 				}

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -81,17 +81,19 @@ class LocaliseModelTranslations extends JModelList
 		);
 		$this->setState(
 			'filter.client',
-			isset($data['select']['client'])  ? $data['select']['client'] : ''
-		);
-		$this->setState(
-			'filter.tag',
-			isset($data['select']['tag'])     ? $data['select']['tag'] : ''
+			isset($data['select']['client'])  ? $data['select']['client'] : 'site'
 		);
 
 		$params    = JComponentHelper::getParams('com_localise');
 		$this->setState('params', $params);
 
 		$reference = $params->get('reference', 'en-GB');
+
+		$this->setState(
+			'filter.tag',
+			isset($data['select']['tag'])     ? $data['select']['tag'] : $reference
+		);
+
 		$this->setState('translations.reference', $reference);
 
 		// Call auto-populate parent method

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -50,12 +50,12 @@ class LocaliseModelTranslations extends JModelList
 		if (empty($data))
 		{
 			$data = array();
-			$data['select'] = $app->getUserState('com_localise.select');
+			$data['select'] = $app->getUserState('com_localise.translations.select');
 			$data['search'] = $app->getUserState('com_localise.translations.search');
 		}
 		else
 		{
-			$app->setUserState('com_localise.select', $data['select']);
+			$app->setUserState('com_localise.translations.select', $data['select']);
 			$app->setUserState('com_localise.translations.search', isset($data['search']) ? $data['search'] : '');
 		}
 

--- a/component/admin/views/translations/tmpl/default_filter.php
+++ b/component/admin/views/translations/tmpl/default_filter.php
@@ -23,9 +23,13 @@ $sortFields = $this->getSortFields();
 			<hr/>
 			<div class="filter-select hidden-phone">
 				<h4 class="page-header"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></h4>
-				<?php foreach ($this->form->getFieldset('select') as $field): ?>
-					<?php echo $field->input; ?>
-					<hr class="hr-condensed"/>
+				<?php foreach ($this->form->getFieldset('select') as $field) : ?>
+					<?php if ($field->type != "Spacer") : ?>
+						<?php echo $field->input; ?>
+						<hr class="hr-condensed"/>
+					<?php else : ?>
+						<?php echo $field->label; ?>
+					<?php endif; ?>
 				<?php endforeach; ?>
 			</div>
 		</div>


### PR DESCRIPTION
Make sure you have a xx-XX (or any tag of a language not installed or for which no xml has yet been created in a core folder (administrator should contain some of them as com_localise copies the languages of its folder into admin lang package).
Filter in the languages view by this language (I used here da-DK) and by administrator, make sure list is set to 20 only (because of the memory limit issue): no language should show.
Then swicth to the translations view:
It will propose all core files for xx-XX (da-DK in my test case) to translate.
This is very wrong.

Go back to languages  and Purge database.
Patch with this PR.
Switch again to translations.

Test for an existing installed language AND for a language for which you have created an xml in the language view. All should be fine.

Because of code style changes (indentation), this PR looks complex, but it just checks if an xx-XX.xml exists each time we have a "foreach ($tags as $tag)"

```
                    foreach ($tags as $tag)
                    {
                        if (JFile::exists($path . '/' . $tag . '/' . $tag . '.xml'))
                        {
```

or

```
if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
```
