### PR TITLE
Improving xx-XX.xml to cope with fields which should not be displayed in the installation xml

### DIFF
--- a/component/admin/models/forms/language.xml
+++ b/component/admin/models/forms/language.xml
@@ -60,7 +60,7 @@
 		<field
 			name="rtl"
 			type="radio"
-			class="btn-group"
+			class="btn-group btn-group-yesno"
 			default="0"
 			required="true"
 			label="COM_LOCALISE_LABEL_LANGUAGE_RTL"

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -291,17 +291,26 @@ class LocaliseModelLanguage extends JModelForm
 			$text .= "\t" . '<version>' . htmlspecialchars($data['version'], ENT_COMPAT, 'UTF-8') . '</version>' . "\n";
 			$text .= "\t" . '<creationDate>' . htmlspecialchars($data['creationDate'], ENT_COMPAT, 'UTF-8') . '</creationDate>' . "\n";
 			$text .= "\t" . '<author>' . htmlspecialchars($data['author'], ENT_COMPAT, 'UTF-8') . '</author>' . "\n";
-			$text .= "\t" . '<authorEmail>' . htmlspecialchars($data['authorEmail'], ENT_COMPAT, 'UTF-8') . '</authorEmail>' . "\n";
-			$text .= "\t" . '<authorUrl>' . htmlspecialchars($data['authorUrl'], ENT_COMPAT, 'UTF-8') . '</authorUrl>' . "\n";
+
+			// AuthorEmail, authorURL are not used in the installation
+			if ($client != "installation")
+			{
+				$text .= "\t" . '<authorEmail>' . htmlspecialchars($data['authorEmail'], ENT_COMPAT, 'UTF-8') . '</authorEmail>' . "\n";
+				$text .= "\t" . '<authorUrl>' . htmlspecialchars($data['authorUrl'], ENT_COMPAT, 'UTF-8') . '</authorUrl>' . "\n";
+			}
 			$text .= "\t" . '<copyright>' . htmlspecialchars($data['joomlacopyright'], ENT_COMPAT, 'UTF-8') . '</copyright>' . "\n";
 
-			$data['copyright'] = explode("\n", $data['copyright']);
-
-			foreach ($data['copyright'] as $copyright)
+			// Author copyright is not used in installation. It is present in CREDITS file
+			if ($client != "installation")
 			{
-				if ($copyright)
+				$data['copyright'] = explode("\n", $data['copyright']);
+
+				foreach ($data['copyright'] as $copyright)
 				{
-					$text .= "\t" . '<copyright>' . htmlspecialchars($copyright, ENT_COMPAT, 'UTF-8') . '</copyright>' . "\n";
+					if ($copyright)
+					{
+						$text .= "\t" . '<copyright>' . htmlspecialchars($copyright, ENT_COMPAT, 'UTF-8') . '</copyright>' . "\n";
+					}
 				}
 			}
 
@@ -336,9 +345,15 @@ class LocaliseModelLanguage extends JModelForm
 			$text .= "\t\t" . '<name>' . htmlspecialchars($data['name'], ENT_COMPAT, 'UTF-8') . '</name>' . "\n";
 			$text .= "\t\t" . '<tag>' . htmlspecialchars($data['tag'], ENT_COMPAT, 'UTF-8') . '</tag>' . "\n";
 			$text .= "\t\t" . '<rtl>' . htmlspecialchars($data['rtl'], ENT_COMPAT, 'UTF-8') . '</rtl>' . "\n";
-			$text .= "\t\t" . '<locale>' . htmlspecialchars($data['locale'], ENT_COMPAT, 'UTF-8') . '</locale>' . "\n";
-			$text .= "\t\t" . '<firstDay>' . htmlspecialchars($data['firstDay'], ENT_COMPAT, 'UTF-8') . '</firstDay>' . "\n";
-			$text .= "\t\t" . '<weekEnd>' . htmlspecialchars($data['weekEnd'], ENT_COMPAT, 'UTF-8') . '</weekEnd>' . "\n";
+
+			// Locale, firstDay and weekEnd are not used in the installation
+			if ($client != "installation")
+			{
+				$text .= "\t\t" . '<locale>' . htmlspecialchars($data['locale'], ENT_COMPAT, 'UTF-8') . '</locale>' . "\n";
+				$text .= "\t\t" . '<firstDay>' . htmlspecialchars($data['firstDay'], ENT_COMPAT, 'UTF-8') . '</firstDay>' . "\n";
+				$text .= "\t\t" . '<weekEnd>' . htmlspecialchars($data['weekEnd'], ENT_COMPAT, 'UTF-8') . '</weekEnd>' . "\n";
+			}
+
 			$text .= "\t" . '</metadata>' . "\n";
 			$text .= "\t" . '<params />' . "\n";
 			$text .= '</metafile>' . "\n";


### PR DESCRIPTION
author email, author url, author copyright, locale, firstday, weekend are not used for the installation xml file.
This PR will prevent saving these fields in that case.

To test: create new languages xml for installation and for site or admin after filling all fields when editing a language
