### PR TITLE
Proposing core translations only when a xx-XX.xml file is present in the xx-XX folder + using one language and one client only in translations view to cope with memory issues

### DIFF
--- a/component/admin/language/en-GB/en-GB.com_localise.ini
+++ b/component/admin/language/en-GB/en-GB.com_localise.ini
@@ -206,6 +206,7 @@ COM_LOCALISE_TOOLTIP_TRANSLATION_AZURE="<b>Windows Azure</b><br/>Click to find a
 
 [Translations]
 
+COM_LOCALISE_ERROR_CHOOSE_LANG_CLIENT="Please choose a client AND a language in the filters before switching to the Translations view"
 COM_LOCALISE_HEADER_TRANSLATIONS="Translations"
 COM_LOCALISE_HEADING_TRANSLATIONS_AUTHOR="Author"
 COM_LOCALISE_HEADING_TRANSLATIONS_INFORMATION="Information"

--- a/component/admin/models/forms/translations.xml
+++ b/component/admin/models/forms/translations.xml
@@ -48,6 +48,9 @@
 				onchange="this.form.submit()">
 				<option value="">COM_LOCALISE_OPTION_TRANSLATIONS_TYPE_SELECT</option>
 			</field>
+			<field name="spacer_client" type="spacer" class="text"
+				label="COM_LOCALISE_OPTION_CLIENT_SELECT"
+			/>
 			<field
 				id="client"
 				name="client"
@@ -55,8 +58,10 @@
 				class="span12 small"
 				hidden="true"
 				onchange="this.form.submit()">
-				<option value="">COM_LOCALISE_OPTION_CLIENT_SELECT</option>
 			</field>
+			<field name="spacer_lang" type="spacer" class="text"
+				label="COM_LOCALISE_OPTION_LANGUAGE_SELECT"
+			/>
 			<field
 				id="tag"
 				name="tag"
@@ -65,7 +70,6 @@
 				client="site"
 				hidden="true"
 				onchange="this.form.submit()">
-				<option value="">COM_LOCALISE_OPTION_LANGUAGE_SELECT</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -50,13 +50,20 @@ class LocaliseModelTranslations extends JModelList
 		if (empty($data))
 		{
 			$data = array();
-			$data['select'] = $app->getUserState('com_localise.translations.select');
+			$data['select'] = $app->getUserState('com_localise.select');
 			$data['search'] = $app->getUserState('com_localise.translations.search');
 		}
 		else
 		{
-			$app->setUserState('com_localise.translations.select', $data['select']);
+			$app->setUserState('com_localise.select', $data['select']);
 			$app->setUserState('com_localise.translations.search', isset($data['search']) ? $data['search'] : '');
+		}
+
+		// Prevent displaying translations view if filters not set for client and language
+		if (empty($data['select']['tag']) || empty($data['select']['client']))
+		{
+			$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_CHOOSE_LANG_CLIENT'), 'error');
+			$app->redirect(JRoute::_('index.php?option=com_localise&view=languages', false));
 		}
 
 		$this->setState(
@@ -81,18 +88,17 @@ class LocaliseModelTranslations extends JModelList
 		);
 		$this->setState(
 			'filter.client',
-			isset($data['select']['client'])  ? $data['select']['client'] : 'site'
+			isset($data['select']['client'])  ? $data['select']['client'] : ''
+		);
+		$this->setState(
+				'filter.tag',
+				isset($data['select']['tag'])     ? $data['select']['tag'] :''
 		);
 
 		$params    = JComponentHelper::getParams('com_localise');
 		$this->setState('params', $params);
 
 		$reference = $params->get('reference', 'en-GB');
-
-		$this->setState(
-			'filter.tag',
-			isset($data['select']['tag'])     ? $data['select']['tag'] : $reference
-		);
 
 		$this->setState('translations.reference', $reference);
 

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -50,12 +50,12 @@ class LocaliseModelTranslations extends JModelList
 		if (empty($data))
 		{
 			$data = array();
-			$data['select'] = $app->getUserState('com_localise.select');
+			$data['select'] = $app->getUserState('com_localise.translations.select');
 			$data['search'] = $app->getUserState('com_localise.translations.search');
 		}
 		else
 		{
-			$app->setUserState('com_localise.select', $data['select']);
+			$app->setUserState('com_localise.translations.select', $data['select']);
 			$app->setUserState('com_localise.translations.search', isset($data['search']) ? $data['search'] : '');
 		}
 
@@ -81,17 +81,19 @@ class LocaliseModelTranslations extends JModelList
 		);
 		$this->setState(
 			'filter.client',
-			isset($data['select']['client'])  ? $data['select']['client'] : ''
-		);
-		$this->setState(
-			'filter.tag',
-			isset($data['select']['tag'])     ? $data['select']['tag'] : ''
+			isset($data['select']['client'])  ? $data['select']['client'] : 'site'
 		);
 
 		$params    = JComponentHelper::getParams('com_localise');
 		$this->setState('params', $params);
 
 		$reference = $params->get('reference', 'en-GB');
+
+		$this->setState(
+			'filter.tag',
+			isset($data['select']['tag'])     ? $data['select']['tag'] : $reference
+		);
+
 		$this->setState('translations.reference', $reference);
 
 		// Call auto-populate parent method
@@ -249,93 +251,96 @@ class LocaliseModelTranslations extends JModelList
 
 					foreach ($tags as $tag)
 					{
-						// For all selected tags
-						$files = JFolder::files("$path/$tag", "$filter_search.*\.ini$");
-
-						foreach ($files as $file)
+						if (JFile::exists($path . '/' . $tag . '/' . $tag . '.xml'))
 						{
-							$filename = substr($file, 1 + strlen($tag));
+							// For all selected tags
+							$files = JFolder::files("$path/$tag", "$filter_search.*\.ini$");
 
-							if ($filename == 'ini')
+							foreach ($files as $file)
 							{
-								$filename = '';
-							}
-							else
-							{
-								$filename = substr($filename, 0, strlen($filename) - 4);
-							}
+								$filename = substr($file, 1 + strlen($tag));
 
-							$origin = LocaliseHelper::getOrigin($filename, $client);
+								if ($filename == 'ini')
+								{
+									$filename = '';
+								}
+								else
+								{
+									$filename = substr($filename, 0, strlen($filename) - 4);
+								}
 
-							if (preg_match("/$filter_origin/", $origin))
-							{
-								$prefix = substr($file, 0, 4 + strlen($tag));
+								$origin = LocaliseHelper::getOrigin($filename, $client);
 
-								$translation = new JObject(
-									array(
-										'tag' => $tag,
-										'client' => $client,
-										'storage' => 'global',
-										'refpath' => null,
-										'path' => "$path/$tag/$file",
-										'state' => $tag == $reftag ? 'inlanguage' : 'notinreference',
-										'writable' => LocaliseHelper::isWritable("$path/$tag/$file"),
-										'origin' => $origin
-									)
-								);
+								if (preg_match("/$filter_origin/", $origin))
+								{
+									$prefix = substr($file, 0, 4 + strlen($tag));
 
-								if ($file == "$tag.ini" && preg_match("/$filter_type/", 'joomla'))
-								{
-									// Scan joomla ini file
-									$translation->setProperties(array('type' => 'joomla', 'filename' => 'joomla', 'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA')));
-									$this->translations["$client|$tag|joomla"] = $translation;
-								}
-								elseif ($file == "$tag.finder_cli.ini")
-								{
-									$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.com" && preg_match("/$filter_type/", 'component'))
-								{
-									// Scan component ini file
-									$translation->setProperties(array('type' => 'component', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.mod" && preg_match("/$filter_type/", 'module'))
-								{
-									// Scan module ini file
-									$translation->setProperties(array('type' => 'module', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.tpl" && preg_match("/$filter_type/", 'template'))
-								{
-									// Scan template ini file
-									$translation->setProperties(array('type' => 'template', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.plg" && preg_match("/$filter_type/", 'plugin'))
-								{
-									// Scan plugin ini file
-									$translation->setProperties(array('type' => 'plugin', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.pkg" && preg_match("/$filter_type/", 'package'))
-								{
-									// Scan package ini file
-									$translation->setProperties(array('type' => 'package', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.lib" && preg_match("/$filter_type/", 'library'))
-								{
-									// Scan library ini file
-									$translation->setProperties(array('type' => 'library', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
-								}
-								elseif ($prefix == "$tag.fil" && preg_match("/$filter_type/", 'file'))
-								{
-									// Scan files ini file
-									$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
-									$this->translations["$client|$tag|$filename"] = $translation;
+									$translation = new JObject(
+										array(
+											'tag' => $tag,
+											'client' => $client,
+											'storage' => 'global',
+											'refpath' => null,
+											'path' => "$path/$tag/$file",
+											'state' => $tag == $reftag ? 'inlanguage' : 'notinreference',
+											'writable' => LocaliseHelper::isWritable("$path/$tag/$file"),
+											'origin' => $origin
+										)
+									);
+
+									if ($file == "$tag.ini" && preg_match("/$filter_type/", 'joomla'))
+									{
+										// Scan joomla ini file
+										$translation->setProperties(array('type' => 'joomla', 'filename' => 'joomla', 'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA')));
+										$this->translations["$client|$tag|joomla"] = $translation;
+									}
+									elseif ($file == "$tag.finder_cli.ini")
+									{
+										$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.com" && preg_match("/$filter_type/", 'component'))
+									{
+										// Scan component ini file
+										$translation->setProperties(array('type' => 'component', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.mod" && preg_match("/$filter_type/", 'module'))
+									{
+										// Scan module ini file
+										$translation->setProperties(array('type' => 'module', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.tpl" && preg_match("/$filter_type/", 'template'))
+									{
+										// Scan template ini file
+										$translation->setProperties(array('type' => 'template', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.plg" && preg_match("/$filter_type/", 'plugin'))
+									{
+										// Scan plugin ini file
+										$translation->setProperties(array('type' => 'plugin', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.pkg" && preg_match("/$filter_type/", 'package'))
+									{
+										// Scan package ini file
+										$translation->setProperties(array('type' => 'package', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.lib" && preg_match("/$filter_type/", 'library'))
+									{
+										// Scan library ini file
+										$translation->setProperties(array('type' => 'library', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
+									elseif ($prefix == "$tag.fil" && preg_match("/$filter_type/", 'file'))
+									{
+										// Scan files ini file
+										$translation->setProperties(array('type' => 'file', 'filename' => $filename, 'name' => $filename));
+										$this->translations["$client|$tag|$filename"] = $translation;
+									}
 								}
 							}
 						}
@@ -379,36 +384,40 @@ class LocaliseModelTranslations extends JModelList
 
 				foreach ($tags as $tag)
 				{
-					if (array_key_exists("$client|$reftag|joomla", $this->translations))
+
+					if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 					{
-						$reftranslation = $this->translations["$client|$reftag|joomla"];
-
-						if (array_key_exists("$client|$tag|joomla", $this->translations))
+						if (array_key_exists("$client|$reftag|joomla", $this->translations))
 						{
-							$this->translations["$client|$tag|joomla"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-						}
-						elseif ($filter_storage != 'local')
-						{
-							$origin = LocaliseHelper::getOrigin("", $client);
+							$reftranslation = $this->translations["$client|$reftag|joomla"];
 
-							$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
+							if (array_key_exists("$client|$tag|joomla", $this->translations))
+							{
+								$this->translations["$client|$tag|joomla"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+							}
+							elseif ($filter_storage != 'local')
+							{
+								$origin = LocaliseHelper::getOrigin("", $client);
 
-							$translation = new JObject(
-								array(
-									'type' => 'joomla',
-									'tag' => $tag,
-									'client' => $client,
-									'storage' => 'global',
-									'filename' => 'joomla',
-									'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA'),
-									'refpath' => $reftranslation->path,
-									'path' => $path,
-									'state' => 'unexisting',
-									'writable' => LocaliseHelper::isWritable($path),
-									'origin' => $origin
-								)
-							);
-							$this->translations["$client|$tag|joomla"] = $translation;
+								$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.ini";
+
+								$translation = new JObject(
+									array(
+										'type' => 'joomla',
+										'tag' => $tag,
+										'client' => $client,
+										'storage' => 'global',
+										'filename' => 'joomla',
+										'name' => JText::_('COM_LOCALISE_TEXT_TRANSLATIONS_JOOMLA'),
+										'refpath' => $reftranslation->path,
+										'path' => $path,
+										'state' => 'unexisting',
+										'writable' => LocaliseHelper::isWritable($path),
+										'origin' => $origin
+									)
+								);
+								$this->translations["$client|$tag|joomla"] = $translation;
+							}
 						}
 					}
 				}
@@ -432,33 +441,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'library',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => 'core'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'library',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => 'core'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -471,33 +483,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'library',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => '_thirdparty'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'library',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => '_thirdparty'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -509,33 +524,36 @@ class LocaliseModelTranslations extends JModelList
 
 							foreach ($tags as $tag)
 							{
-								if (array_key_exists("$client|$reftag|$name", $this->translations))
+								if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 								{
-									$reftranslation = $this->translations["$client|$reftag|$name"];
+									if (array_key_exists("$client|$reftag|$name", $this->translations))
+									{
+										$reftranslation = $this->translations["$client|$reftag|$name"];
 
-									if (array_key_exists("$client|$tag|$name", $this->translations))
-									{
-										$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-									}
-									else
-									{
-										$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
-										$translation = new JObject(
-											array(
-												'type' => 'package',
-												'tag' => $tag,
-												'client' => $client,
-												'storage' => 'global',
-												'filename' => $name,
-												'name' => $name,
-												'refpath' => $reftranslation->path,
-												'path' => $path,
-												'state' => 'unexisting',
-												'writable' => LocaliseHelper::isWritable($path),
-												'origin' => '_thirdparty'
-											)
-										);
-										$this->translations["$client|$tag|$name"] = $translation;
+										if (array_key_exists("$client|$tag|$name", $this->translations))
+										{
+											$this->translations["$client|$tag|$name"]->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+										}
+										else
+										{
+											$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$name.ini";
+											$translation = new JObject(
+												array(
+													'type' => 'package',
+													'tag' => $tag,
+													'client' => $client,
+													'storage' => 'global',
+													'filename' => $name,
+													'name' => $name,
+													'refpath' => $reftranslation->path,
+													'path' => $path,
+													'state' => 'unexisting',
+													'writable' => LocaliseHelper::isWritable($path),
+													'origin' => '_thirdparty'
+												)
+											);
+											$this->translations["$client|$tag|$name"] = $translation;
+										}
 									}
 								}
 							}
@@ -614,31 +632,34 @@ class LocaliseModelTranslations extends JModelList
 					{
 						$origin = LocaliseHelper::getOrigin("$prefix$extension$suffix", $client);
 
-						if (array_key_exists("$client|$tag|$prefix$extension$suffix", $this->translations))
+						if (JFile::exists($client_folder . '/' . $tag . '/' . $tag . '.xml'))
 						{
-							$this
-								->translations["$client|$tag|$prefix$extension$suffix"]
-								->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
-						}
-						elseif ($filter_storage != 'local' && ($filter_origin == '' || $filter_origin == $origin))
-						{
-							$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$prefix$extension$suffix.ini";
-							$translation = new JObject(
-								array(
-									'type' => $type,
-									'tag' => $tag,
-									'client' => $client,
-									'storage' => 'global',
-									'filename' => "$prefix$extension$suffix",
-									'name' => "$prefix$extension$suffix",
-									'refpath' => $reftranslation->path,
-									'path' => $path, 'state' => 'unexisting',
-									'writable' => LocaliseHelper::isWritable($path),
-									'origin' => $origin
-								)
-							);
+							if (array_key_exists("$client|$tag|$prefix$extension$suffix", $this->translations))
+							{
+								$this
+									->translations["$client|$tag|$prefix$extension$suffix"]
+									->setProperties(array('refpath' => $reftranslation->path, 'state' => 'inlanguage'));
+							}
+							elseif ($filter_storage != 'local' && ($filter_origin == '' || $filter_origin == $origin))
+							{
+								$path = constant('LOCALISEPATH_' . strtoupper($client)) . "/language/$tag/$tag.$prefix$extension$suffix.ini";
+								$translation = new JObject(
+									array(
+										'type' => $type,
+										'tag' => $tag,
+										'client' => $client,
+										'storage' => 'global',
+										'filename' => "$prefix$extension$suffix",
+										'name' => "$prefix$extension$suffix",
+										'refpath' => $reftranslation->path,
+										'path' => $path, 'state' => 'unexisting',
+										'writable' => LocaliseHelper::isWritable($path),
+										'origin' => $origin
+									)
+								);
 
-							$this->translations["$client|$tag|$prefix$extension$suffix"] = $translation;
+								$this->translations["$client|$tag|$prefix$extension$suffix"] = $translation;
+							}
 						}
 					}
 				}

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -91,8 +91,8 @@ class LocaliseModelTranslations extends JModelList
 			isset($data['select']['client'])  ? $data['select']['client'] : ''
 		);
 		$this->setState(
-				'filter.tag',
-				isset($data['select']['tag'])     ? $data['select']['tag'] :''
+			'filter.tag',
+			isset($data['select']['tag'])     ? $data['select']['tag'] :''
 		);
 
 		$params    = JComponentHelper::getParams('com_localise');

--- a/component/admin/views/translations/tmpl/default_filter.php
+++ b/component/admin/views/translations/tmpl/default_filter.php
@@ -23,9 +23,13 @@ $sortFields = $this->getSortFields();
 			<hr/>
 			<div class="filter-select hidden-phone">
 				<h4 class="page-header"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></h4>
-				<?php foreach ($this->form->getFieldset('select') as $field): ?>
-					<?php echo $field->input; ?>
-					<hr class="hr-condensed"/>
+				<?php foreach ($this->form->getFieldset('select') as $field) : ?>
+					<?php if ($field->type != "Spacer") : ?>
+						<?php echo $field->input; ?>
+						<hr class="hr-condensed"/>
+					<?php else : ?>
+						<?php echo $field->label; ?>
+					<?php endif; ?>
 				<?php endforeach; ?>
 			</div>
 		</div>


### PR DESCRIPTION
replaces https://github.com/joomla-projects/com_localise/pull/190 which was merged per error and then reverted

See there for instructions.
# DO NOT MERGE until the filters issue is fixed

https://github.com/joomla-projects/com_localise/pull/190#issuecomment-52289516
