### PR TITLE
Solving issues with new language save

### DIFF
--- a/component/admin/controllers/language.php
+++ b/component/admin/controllers/language.php
@@ -74,6 +74,7 @@ class LocaliseControllerLanguage extends JControllerForm
 	{
 		// Get the infos
 		$input = JFactory::getApplication()->input;
+		$client = $input->get('client', '');
 
 		if (empty($client))
 		{

--- a/component/admin/controllers/language.php
+++ b/component/admin/controllers/language.php
@@ -74,23 +74,17 @@ class LocaliseControllerLanguage extends JControllerForm
 	{
 		// Get the infos
 		$input = JFactory::getApplication()->input;
-		$client = $input->get('client', '');
+
+		if (empty($client))
+		{
+			$data = $input->get('jform', array(), 'array');
+			$client = $data['client'];
+		}
 
 		if (empty($client))
 		{
 			$select = $input->get('filters', array(), 'array');
 			$client = isset($select['select']['client']) ? $select['select']['client'] : 'site';
-		}
-
-		if (empty($client))
-		{
-			$data = $input->get('jform', array(), 'array');
-			$client = isset($data['client']) ? $data['client'] : 'site';
-		}
-
-		if (empty($client))
-		{
-			$client = 'site';
 		}
 
 		$tag = $input->get('tag', '');

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -103,6 +103,12 @@ class LocaliseModelLanguage extends JModelForm
 		// Get the form.
 		$form = $this->loadForm('com_localise.language', 'language', array('control'   => 'jform', 'load_data' => $loadData));
 
+		// Make Client field readonly when the file exists
+		if ($this->getState('language.id'))
+		{
+			$form->setFieldAttribute('client', 'readonly', 'true');
+		}
+
 		return $form;
 	}
 
@@ -371,6 +377,10 @@ class LocaliseModelLanguage extends JModelForm
 			}
 
 			$id = LocaliseHelper::getFileId($path);
+
+			// Dummy call to populate state
+			$this->getState('language.id');
+
 			$this->setState('language.id', $id);
 
 			// Bind the rules.


### PR DESCRIPTION
This is a common work with @Achal-Aggarwal.

It solves https://github.com/joomla-projects/com_localise/issues/198
It also prevents the new saved language to have the wrong client displayed on redirect after Save. 
Also it makes the client field readonly preventing issues when an edited language xml already exists for that client.

To test: create new language xml for different clients after setting the Languages view settings to different values for client, including all clients. Save (Not Save and Close) and check that the xml is the correct one displayed.
