### PR TITLE
[review #17] Models: Use getUserStateFromRequest on populateState

### DIFF
--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -20,6 +20,11 @@ jimport('joomla.access.rules');
  */
 class LocaliseModelLanguage extends JModelForm
 {
+	/**
+	 * Model context string.
+	 *
+	 * @var		string
+	 */
 	protected $context = 'com_localise.language';
 
 	/**
@@ -29,11 +34,11 @@ class LocaliseModelLanguage extends JModelForm
 	 */
 	protected function populateState()
 	{
-		$jinput = JFactory::getApplication()->input;
+		$app    = JFactory::getApplication();
 
-		$client = $jinput->get('client', 'site', 'cmd');
-		$tag    = $jinput->get('tag', '', 'cmd');
-		$id     = $jinput->get('id', '0', 'int');
+		$client = $app->getUserStateFromRequest($this->context . '.client', 'client');
+		$tag    = $app->getUserStateFromRequest($this->context . '.tag', 'tag');
+		$id     = $app->getUserStateFromRequest($this->context . '.id', 'id');
 
 		$this->setState('language.client', $client);
 		$this->setState('language.tag', $tag);


### PR DESCRIPTION
Please review the changes for this one view, then we may proceed for all.

Here class is extended from `JModelForm` https://github.com/joomla-projects/com_localise/blob/develop/component/admin/models/language.php#L21 that's why we can use,

``` Php
$name = $this->getUserStateFromRequest($this->_context . '.name', 'name');
```

**Contains fix for #17**

_Question: We should use `JModelAdmin` here or it's fine with `JModelForm`?_
