### PR TITLE
Displaying the checkout icon when necessary

### DIFF
--- a/component/admin/controllers/languages.php
+++ b/component/admin/controllers/languages.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
  * @subpackage  Localise
  * @since       1.0
  */
-class LocaliseControllerLanguages extends JControllerLegacy
+class LocaliseControllerLanguages extends JControllerAdmin
 {
 	/**
 	 * Method to purge the localise table.

--- a/component/admin/controllers/packages.php
+++ b/component/admin/controllers/packages.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
  * @subpackage  Localise
  * @since       1.0
  */
-class LocaliseControllerPackages extends JControllerLegacy
+class LocaliseControllerPackages extends JControllerAdmin
 {
 	/**
 	 * Proxy for getModel.

--- a/component/admin/controllers/translations.php
+++ b/component/admin/controllers/translations.php
@@ -16,6 +16,6 @@ defined('_JEXEC') or die;
  * @subpackage  Localise
  * @since       1.0
  */
-class LocaliseControllerTranslations extends JControllerLegacy
+class LocaliseControllerTranslations extends JControllerAdmin
 {
 }

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -43,27 +43,13 @@ class LocaliseModelLanguage extends JModelForm
 	}
 
 	/**
-	 * Method to override check-out a row for editing.
-	 *
-	 * @param   int  $pk  The ID of the primary key.
-	 *
-	 * @return  boolean
-	 */
-	public function checkout($pk = null)
-	{
-		$app = JFactory::getApplication('administrator');
-		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.language.id');
-
-		return parent::checkout($pk);
-	}
-
-	/**
 	 * Method to checkin a row.
 	 *
-	 * @param   int  $pk  The ID of the primary key.
+	 * @param   integer  $pk  The numeric id of the primary key.
 	 *
-	 * @return  boolean
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
 	 */
 	public function checkin($pk = null)
 	{
@@ -71,9 +57,92 @@ class LocaliseModelLanguage extends JModelForm
 		// Initialise variables.
 		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.language.id');
 
-		return parent::checkin($pk);
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			$user = JFactory::getUser();
+
+			// Get an instance of the row to checkin.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=languages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row in.
+			if (!$table->checkin($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
+	/**
+	 * Method to check-out a row for editing.
+	 *
+	 * @param   integer  $pk  The numeric id of the primary key.
+	 *
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public function checkout($pk = null)
+	{
+		$app = JFactory::getApplication('administrator');
+		// Initialise variables.
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.language.id');
+
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			// Get an instance of the row to checkout.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			$user = JFactory::getUser();
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=languages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row out.
+			if (!$table->checkout($user->get('id'), $pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
+	}
 
 	/**
 	 * Returns a Table object, always creating it.

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -51,16 +51,15 @@ class LocaliseModelLanguage extends JModelForm
 	 */
 	public function checkout($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk))
-			? $pk
-			: (int) $this->getState('language.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.language.id');
 
 		return parent::checkout($pk);
 	}
 
 	/**
-	 * Method to checking a row.
+	 * Method to checkin a row.
 	 *
 	 * @param   int  $pk  The ID of the primary key.
 	 *
@@ -68,13 +67,13 @@ class LocaliseModelLanguage extends JModelForm
 	 */
 	public function checkin($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk))
-			? $pk
-			: (int) $this->getState('language.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.language.id');
 
 		return parent::checkin($pk);
 	}
+
 
 	/**
 	 * Returns a Table object, always creating it.

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -57,8 +57,9 @@ class LocaliseModelPackage extends JModelForm
 	 */
 	public function checkout($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $this->getState('package.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
 		return parent::checkout($pk);
 	}
@@ -72,11 +73,13 @@ class LocaliseModelPackage extends JModelForm
 	 */
 	public function checkin($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $this->getState('package.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
 		return parent::checkin($pk);
 	}
+
 
 	/**
 	 * Returns a Table object, always creating it.

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -49,27 +49,13 @@ class LocaliseModelPackage extends JModelForm
 	}
 
 	/**
-	 * Method to override check-out a row for editing.
-	 *
-	 * @param   int  $pk  The ID of the primary key.
-	 *
-	 * @return  boolean
-	 */
-	public function checkout($pk = null)
-	{
-		$app = JFactory::getApplication('administrator');
-		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
-
-		return parent::checkout($pk);
-	}
-
-	/**
 	 * Method to checkin a row.
 	 *
-	 * @param   int  $pk  The ID of the primary key.
+	 * @param   integer  $pk  The numeric id of the primary key.
 	 *
-	 * @return  boolean
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
 	 */
 	public function checkin($pk = null)
 	{
@@ -77,9 +63,92 @@ class LocaliseModelPackage extends JModelForm
 		// Initialise variables.
 		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
-		return parent::checkin($pk);
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			$user = JFactory::getUser();
+
+			// Get an instance of the row to checkin.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row in.
+			if (!$table->checkin($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
+	/**
+	 * Method to check-out a row for editing.
+	 *
+	 * @param   integer  $pk  The numeric id of the primary key.
+	 *
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public function checkout($pk = null)
+	{
+		$app = JFactory::getApplication('administrator');
+		// Initialise variables.
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
+
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			// Get an instance of the row to checkout.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			$user = JFactory::getUser();
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row out.
+			if (!$table->checkout($user->get('id'), $pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
+	}
 
 	/**
 	 * Returns a Table object, always creating it.

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -57,8 +57,9 @@ class LocaliseModelPackageFile extends JModelForm
 	 */
 	public function checkout($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $this->getState('package.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
 		return parent::checkout($pk);
 	}
@@ -72,8 +73,9 @@ class LocaliseModelPackageFile extends JModelForm
 	 */
 	public function checkin($pk = null)
 	{
+		$app = JFactory::getApplication('administrator');
 		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $this->getState('package.id');
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
 		return parent::checkin($pk);
 	}

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -49,27 +49,13 @@ class LocaliseModelPackageFile extends JModelForm
 	}
 
 	/**
-	 * Method to override check-out a row for editing.
-	 *
-	 * @param   int  $pk  The ID of the primary key.
-	 *
-	 * @return  boolean
-	 */
-	public function checkout($pk = null)
-	{
-		$app = JFactory::getApplication('administrator');
-		// Initialise variables.
-		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
-
-		return parent::checkout($pk);
-	}
-
-	/**
 	 * Method to checkin a row.
 	 *
-	 * @param   int  $pk  The ID of the primary key.
+	 * @param   integer  $pk  The numeric id of the primary key.
 	 *
-	 * @return  boolean
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
 	 */
 	public function checkin($pk = null)
 	{
@@ -77,7 +63,91 @@ class LocaliseModelPackageFile extends JModelForm
 		// Initialise variables.
 		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
 
-		return parent::checkin($pk);
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			$user = JFactory::getUser();
+
+			// Get an instance of the row to checkin.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row in.
+			if (!$table->checkin($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Method to check-out a row for editing.
+	 *
+	 * @param   integer  $pk  The numeric id of the primary key.
+	 *
+	 * @return  boolean  False on failure or error, true otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public function checkout($pk = null)
+	{
+		$app = JFactory::getApplication('administrator');
+		// Initialise variables.
+		$pk = (!empty($pk)) ? $pk : (int) $app->getUserState('com_localise.edit.package.id');
+
+		// Only attempt to check the row in if it exists.
+		if ($pk)
+		{
+			// Get an instance of the row to checkout.
+			$table = $this->getTable();
+
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
+			$user = JFactory::getUser();
+
+			// Check if this is the user having previously checked out the row.
+			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
+			{
+				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+
+				return false;
+			}
+
+			// Attempt to check the row out.
+			if (!$table->checkout($user->get('id'), $pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/component/admin/views/languages/tmpl/default_body.php
+++ b/component/admin/views/languages/tmpl/default_body.php
@@ -44,12 +44,13 @@ JFactory::getDocument()->addScriptDeclaration("
 ");
 ?>
 <?php foreach($this->items as $i => $item): ?>
-	<?php $canEdit   = $user->authorise('localise.edit', 'com_localise.'.$item->id);?>
-	<?php $canDelete = $user->authorise('localise.delete', 'com_localise.'.$item->id);?>
+	<?php $canEdit   = $user->authorise('localise.edit', 'com_localise.'.$item->id); ?>
+	<?php $canDelete = $user->authorise('localise.delete', 'com_localise.'.$item->id); ?>
+	<?php $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0; ?>
 	<tr class="row<?php echo $i % 2; ?>">
 		<td width="20" class="center hidden-phone">
 			<?php if ($item->checked_out) : ?>
-				<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time); ?>
+				<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time, '', $canCheckin); ?>
 			<?php elseif ($canDelete): ?>
 				<a href="#" data-id="<?php echo $item->id; ?>" data-client="<?php echo $item->client; ?>" data-tag="<?php echo $item->tag; ?>" class="hasTooltip js-list-delete-item" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_LANGUAGES_DELETE'); ?>">
 					<i class="icon-16-delete"></i>

--- a/component/admin/views/languages/tmpl/default_body.php
+++ b/component/admin/views/languages/tmpl/default_body.php
@@ -50,7 +50,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<tr class="row<?php echo $i % 2; ?>">
 		<td width="20" class="center hidden-phone">
 			<?php if ($item->checked_out) : ?>
-				<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time, '', $canCheckin); ?>
+				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'languages.', $canCheckin); ?>
 			<?php elseif ($canDelete): ?>
 				<a href="#" data-id="<?php echo $item->id; ?>" data-client="<?php echo $item->client; ?>" data-tag="<?php echo $item->tag; ?>" class="hasTooltip js-list-delete-item" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_LANGUAGES_DELETE'); ?>">
 					<i class="icon-16-delete"></i>

--- a/component/admin/views/packages/tmpl/default_body.php
+++ b/component/admin/views/packages/tmpl/default_body.php
@@ -9,18 +9,20 @@
 
 defined('_JEXEC') or die;
 
-$user     = JFactory::getUser();
+$user = JFactory::getUser();
+
 ?>
 <?php foreach($this->items as $i => $item) : ?>
 	<?php if ($item->name !== 'core') : ?>
 		<?php $canEdit = $user->authorise('localise.edit', 'com_localise.'.$item->id); ?>
+		<?php $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0; ?>
 		<tr class="row<?php echo $i % 2; ?>">
 			<td width="20" class="center hidden-phone"><?php echo $i + 1; ?></td>
 			<td width="20" class="center hidden-phone">
-				<?php if (empty($item->checked_out)) : ?>
+				<?php if ($item->checked_out) : ?>
+					<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time, '', $canCheckin); ?>
+				<?php else : ?>
 					<?php echo JHtml::_('grid.id', $i, $item->name); ?>
-				<?php else:?>
-					<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time); ?>
 				<?php endif; ?>
 			</td>
 			<td>

--- a/component/admin/views/packages/tmpl/default_body.php
+++ b/component/admin/views/packages/tmpl/default_body.php
@@ -20,7 +20,7 @@ $user = JFactory::getUser();
 			<td width="20" class="center hidden-phone"><?php echo $i + 1; ?></td>
 			<td width="20" class="center hidden-phone">
 				<?php if ($item->checked_out) : ?>
-					<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', $canCheckin); ?>
+					<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'packages.', $canCheckin); ?>
 				<?php else : ?>
 					<?php echo JHtml::_('grid.id', $i, $item->name); ?>
 				<?php endif; ?>

--- a/component/admin/views/packages/tmpl/default_body.php
+++ b/component/admin/views/packages/tmpl/default_body.php
@@ -20,7 +20,7 @@ $user = JFactory::getUser();
 			<td width="20" class="center hidden-phone"><?php echo $i + 1; ?></td>
 			<td width="20" class="center hidden-phone">
 				<?php if ($item->checked_out) : ?>
-					<?php echo JHtml::_('jgrid.checkedout', $item->editor, $item->checked_out_time, '', $canCheckin); ?>
+					<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', $canCheckin); ?>
 				<?php else : ?>
 					<?php echo JHtml::_('grid.id', $i, $item->name); ?>
 				<?php endif; ?>

--- a/component/admin/views/translations/tmpl/default_body.php
+++ b/component/admin/views/translations/tmpl/default_body.php
@@ -14,11 +14,11 @@ $params = JComponentHelper::getParams('com_localise');
 $reference = $params->get('reference', 'en-GB');
 $packages = LocaliseHelper::getPackages();
 $user = JFactory::getUser();
-$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 $lang = JFactory::getLanguage();
 ?>
 <?php foreach ($this->items as $i => $item) : ?>
 	<?php $canEdit = $user->authorise('localise.edit', 'com_localise' . (isset($item->id) ? ('.' . $item->id) : '')); ?>
+	<?php $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0; ?>
 	<tr class="<?php echo $item->state; ?> row<?php echo $i % 2; ?>">
 		<td width="20" class="center hidden-phone"><?php echo $i + 1; ?></td>
 		<td width="120" class="center hidden-phone">
@@ -58,7 +58,7 @@ $lang = JFactory::getLanguage();
 		<td dir="ltr" class="center"><?php echo $item->client ?></td>
 		<td dir="ltr">
 			<?php if ($item->checked_out) : ?>
-				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, $canCheckin); ?>
+				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', $canCheckin); ?>
 			<?php endif; ?>
 			<?php if ($item->writable && !$item->error && $canEdit) : ?>
 				<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)).($item->filename=='override' ? '&layout=raw' :'')); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">

--- a/component/admin/views/translations/tmpl/default_body.php
+++ b/component/admin/views/translations/tmpl/default_body.php
@@ -58,7 +58,7 @@ $lang = JFactory::getLanguage();
 		<td dir="ltr" class="center"><?php echo $item->client ?></td>
 		<td dir="ltr">
 			<?php if ($item->checked_out) : ?>
-				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', $canCheckin); ?>
+				<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'translations.', $canCheckin); ?>
 			<?php endif; ?>
 			<?php if ($item->writable && !$item->error && $canEdit) : ?>
 				<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)).($item->filename=='override' ? '&layout=raw' :'')); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">


### PR DESCRIPTION
https://github.com/joomla-projects/com_localise/issues/208
To test use 2 browsers and edit a package, a translation or a language.
before patch = errors
after patch: the icon displays, example below for packages

![screen shot 2014-08-30 at 19 35 35](https://cloud.githubusercontent.com/assets/869724/4099726/25b96a5c-306c-11e4-8f4e-b55ccebf0ae3.png)

IMPORTANT: this is incomplete!
Instead of redirecting to the manager when someone clicks on the link of a checkedout item, it opens the edit page and as the close does not work, the only way for the user is to get back in browser.
