### PR TITLE
[fix] strings containing HTML code are not saved

### DIFF
--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -1012,9 +1012,13 @@ class LocaliseModelTranslation extends JModelForm
 	{
 		// Fix DOT saving issue
 		$input = JFactory::getApplication()->input;
-		$strings_array   = $input->post->getArray();
-		$strings         = $strings_array['jform']['strings'];
-		$data['strings'] = $strings;
+
+		$formData = $input->get('jform', array(), 'ARRAY');
+
+		if (!empty($formData['strings']))
+		{
+			$data['strings'] = $formData['strings'];
+		}
 
 		// Special case for lib_joomla
 		if ($this->getState('translation.filename') == 'lib_joomla')


### PR DESCRIPTION
## Reproduce the issue

Edit a translation with standard editor (clicking on the name). Modify any string to add HTML code inside. Example: "My language string for <strong>Jean-Marie</strong>" (note the strong tags)
## Expected result

HTML is saved
## Result

HTML is cleared because the way that $_POST data is received by the model
## Patch test

Apply the patch and check it. HTML should be saved correctly.
