### PR TITLE
Deleting db rows when deleting packages

### DIFF
--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -544,11 +544,20 @@ class LocaliseModelPackage extends JModelAdmin
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
 
-			// Don't just set the user state, first check if the old is present then replace it with new one.
+			if (!$table->delete((int) $originalId))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
 			$app->setUserState('com_localise.edit.package.id', $id);
 
-			// @todo : Delete the old row from table.
+			// Redirect to the new $id as name has changed
+			$app->redirect(JRoute::_('index.php?option=com_localise&view=package&layout=edit&id=' . $this->getState('package.id'), false));
 		}
+
+		$this->cleanCache();
 
 		return true;
 	}

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -523,7 +523,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 			return false;
 		}
 
-		// Delete the older file
+	// Delete the older file
 		if ($path !== $oldpath && file_exists($oldpath))
 		{
 			if (!JFile::delete($oldpath))
@@ -531,11 +531,20 @@ class LocaliseModelPackageFile extends JModelAdmin
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
 
-			// Don't just set the user state, first check if the old is present then replace it with new one.
+			if (!$table->delete((int) $originalId))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
 			$app->setUserState('com_localise.edit.packagefile.id', $id);
 
-			// @todo : Delete the old row from table.
+			// Redirect to the new $id as name has changed
+			$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('package.id'), false));
 		}
+
+		$this->cleanCache();
 
 		return true;
 	}

--- a/component/admin/models/packages.php
+++ b/component/admin/models/packages.php
@@ -204,6 +204,12 @@ class LocaliseModelPackages extends JModelList
 	 */
 	public function delete($selected)
 	{
+		// Sanitize the array.
+		$selected = (array) $selected;
+
+		// Get a row instance.
+		$table = JTable::getInstance('Localise', 'LocaliseTable');
+
 		foreach ($selected as $packageId)
 		{
 			$path = LocaliseHelper::getFilePath($packageId);
@@ -212,6 +218,13 @@ class LocaliseModelPackages extends JModelList
 			if (!JFile::delete($path))
 			{
 				$this->setError(JText::sprintf('COM_LOCALISE_ERROR_PACKAGES_REMOVE', $package));
+
+				return false;
+			}
+
+			if (!$table->delete((int) $packageId))
+			{
+				$this->setError($table->getError());
 
 				return false;
 			}


### PR DESCRIPTION
Test: Duplicate some packages in the packages manager.
Tick some of the duplicated packages and Click on Delete button.

Now the rows in the _assets table as well as in the _localise table will also be deleted.
