### PR TITLE
Improving parsing errors in Translations manager

### DIFF
--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -237,31 +237,35 @@ class LocaliseModelTranslation extends JModelAdmin
 						$line = $stream->gets();
 						$lineNumber++;
 
-						if ($line[0] == '#' || $line[0] == ';')
+						if ($line[0] == '#')
 						{
-							if (preg_match('/^(#|;).*(\$Id.*\$)/', $line, $matches))
+							$this->item->error[] = $lineNumber;
+						}
+						elseif ($line[0] == ';')
+						{
+							if (preg_match('/^(;).*(\$Id.*\$)/', $line, $matches))
 							{
 								$this->item->svn = $matches[2];
 							}
-							elseif (preg_match('/(#|;)\s*@?(\pL+):?.*/', $line, $matches))
+							elseif (preg_match('/(;)\s*@?(\pL+):?.*/', $line, $matches))
 							{
 								switch (strtolower($matches[2]))
 								{
 									case 'note':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->complete = $this->item->complete || strtolower($matches2[3]) == 'complete';
 										break;
 									case 'version':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->version = $matches2[3];
 										break;
 									case 'desc':
 									case 'description':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->description = $matches2[3];
 										break;
 									case 'date':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->creationdate = $matches2[3];
 										break;
 									case 'author':
@@ -271,12 +275,12 @@ class LocaliseModelTranslation extends JModelAdmin
 										}
 										else
 										{
-											preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+											preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 											$this->item->author = $matches2[3];
 										}
 										break;
 									case 'copyright':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 
 										if (empty($this->item->maincopyright))
 										{
@@ -309,16 +313,16 @@ class LocaliseModelTranslation extends JModelAdmin
 										}
 										else
 										{
-											preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+											preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 											$this->item->license = $matches2[3];
 										}
 										break;
 									case 'package':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->package = $matches2[3];
 										break;
 									case 'subpackage':
-										preg_match('/(#|;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
+										preg_match('/(;)\s*@?(\pL+):?\s+(.*)/', $line, $matches2);
 										$this->item->subpackage = $matches2[3];
 										break;
 									case 'link':
@@ -332,7 +336,7 @@ class LocaliseModelTranslation extends JModelAdmin
 											}
 											else
 											{
-												preg_match('/(#|;)\s*(.*)/', $line, $matches2);
+												preg_match('/(;)\s*(.*)/', $line, $matches2);
 												$this->item->author = $matches2[2];
 											}
 										}


### PR DESCRIPTION
Test:
change ; to # in one of the top commented lines of an ini file:
Example:

```
# @date        2014-09-17
; @author      Joomla! Project
; @copyright   (C) 2005 - 2014 Open Source Matters. All rights reserved.
; @copyright   joomla.fr
; @license     GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
; @note        Client Administrator
; @note        All ini files need to be saved as UTF-8 - No BOM
```

com_localise will not find the error in the ini file:
we will get:
![screen shot 2014-09-26 at 11 12 18](https://cloud.githubusercontent.com/assets/869724/4418226/5395df22-455d-11e4-85db-5ab91c46184c.png)

after patch we will righfully see the file in error:
![screen shot 2014-09-26 at 11 13 55](https://cloud.githubusercontent.com/assets/869724/4418242/80cb7bd2-455d-11e4-994e-4c1f4f926e66.png)
