### PR TITLE
Displaying in Translations Manager the ini files from plugins' language folder

### DIFF
--- a/component/admin/helpers/localise.php
+++ b/component/admin/helpers/localise.php
@@ -572,8 +572,8 @@ abstract class LocaliseHelper
 					$parts  = explode('_', $extension);
 					$group  = $parts[1];
 					$parts	= explode('.', $filename);
-					$filename = $parts[0];
-					$plugin = substr($filename, 5 + strlen($group));
+					$pluginname = $parts[0];
+					$plugin = substr($pluginname, 5 + strlen($group));
 					$path   = JPATH_PLUGINS . "/$group/$plugin/language/$tag/$tag.$filename.ini";
 
 					break;

--- a/component/admin/helpers/localise.php
+++ b/component/admin/helpers/localise.php
@@ -287,6 +287,37 @@ abstract class LocaliseHelper
 					);
 				}
 			}
+
+			// Scan plugins folders
+			if (preg_match("/$filter_type/", 'plugin'))
+			{
+				$plugin_types = JFolder::folders(JPATH_PLUGINS);
+
+				foreach ($plugin_types as $plugin_type)
+				{
+					// Scan administrator language folders as this is where plugin languages are installed
+					$scans[] = array(
+						'prefix' => 'plg_' . $plugin_type . '_',
+						'suffix' => '',
+						'type'   => 'plugin',
+						'client' => 'administrator',
+						'path'   => JPATH_PLUGINS . "/$plugin_type/",
+						'folder' => ''
+					);
+
+					foreach ($suffixes as $suffix)
+					{
+						$scans[] = array(
+							'prefix' => 'plg_' . $plugin_type . '_',
+							'suffix' => $suffix,
+							'type'   => 'plugin',
+							'client' => 'administrator',
+							'path'   => JPATH_PLUGINS . "/$plugin_type/",
+							'folder' => ''
+						);
+					}
+				}
+			}
 		}
 
 		// Scan site folders
@@ -363,37 +394,6 @@ abstract class LocaliseHelper
 						'client' => 'site',
 						'path'   => LOCALISEPATH_SITE . '/templates/',
 						'folder' => ''
-					);
-				}
-			}
-		}
-
-		// Scan plugins folders
-		if (preg_match("/$filter_type/", 'plugin'))
-		{
-			$plugin_types = JFolder::folders(JPATH_PLUGINS);
-
-			foreach ($plugin_types as $plugin_type)
-			{
-				// Scan administrator language folders as this is where plugin languages are installed
-				$scans[] = array(
-					'prefix' => 'plg_' . $plugin_type . '_',
-					'suffix' => '',
-					'type'   => 'plugin',
-					'client' => 'administrator',
-					'path'   => JPATH_PLUGINS . "/$plugin_type/",
-					'folder' => '/administrator'
-				);
-
-				foreach ($suffixes as $suffix)
-				{
-					$scans[] = array(
-						'prefix' => 'plg_' . $plugin_type . '_',
-						'suffix' => $suffix,
-						'type'   => 'plugin',
-						'client' => 'administrator',
-						'path'   => JPATH_PLUGINS . "/$plugin_type/",
-						'folder' => '/administrator'
 					);
 				}
 			}

--- a/component/admin/helpers/localise.php
+++ b/component/admin/helpers/localise.php
@@ -571,6 +571,8 @@ abstract class LocaliseHelper
 				case 'plg':
 					$parts  = explode('_', $extension);
 					$group  = $parts[1];
+					$parts	= explode('.', $filename);
+					$filename = $parts[0];
 					$plugin = substr($filename, 5 + strlen($group));
 					$path   = JPATH_PLUGINS . "/$group/$plugin/language/$tag/$tag.$filename.ini";
 

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -175,14 +175,14 @@ class LocaliseModelTranslations extends JModelList
 
 				foreach ($extensions as $extension)
 				{
-					if (JFolder::exists("$path$extension$folder/language"))
+					if (JFolder::exists("$path$extension/language"))
 					{
 						// Scan extensions folder
-						$tags = JFolder::folders("$path$extension$folder/language", $filter_tag);
+						$tags = JFolder::folders("$path$extension/language", $filter_tag);
 
 						foreach ($tags as $tag)
 						{
-							$file   = "$path$extension$folder/language/$tag/$tag.$prefix$extension$suffix.ini";
+							$file   = "$path$extension/language/$tag/$tag.$prefix$extension$suffix.ini";
 							$origin = LocaliseHelper::getOrigin("$prefix$extension$suffix", $client);
 
 							if (JFile::exists($file) && preg_match("/$filter_origin/", $origin))
@@ -428,7 +428,9 @@ class LocaliseModelTranslations extends JModelList
 					{
 						// Coping with Core files not considered as reference
 						if ($file == $reftag . '.com_messages.ini' || $file == $reftag . '.com_mailto.sys.ini'
-							|| $file == $reftag . '.com_wrapper.ini'|| $file == $reftag . '.com_wrapper.sys.ini' || $file == $reftag . '.finder_cli.ini')
+							|| $file == $reftag . '.com_wrapper.ini'|| $file == $reftag . '.com_wrapper.sys.ini' || $file == $reftag . '.finder_cli.ini'
+							|| $file == $reftag . '.plg_user_session.ini' || $file == $reftag . '.plg_user_session.sys.ini'
+							|| $file == $reftag . '.plg_system_session.ini' || $file == $reftag . '.plg_system_session.sys.ini')
 						{
 							$reftaglength = strlen($reftag);
 


### PR DESCRIPTION
The plugin language files when only available in the plugin folder are not proposed to translation.
This PR will display them.
To test, install https://www.dropbox.com/s/c9o8sxtud7swebj/jostag_plugin.zip?dl=0
Then choose in Translations Manager an installed language (not fr-FR or en-GB) 
test before and after patch

This does not totally solve the issue as we can translate the .ini but not the .sys.ini.
It seems that one is not loaded.
