### PR TITLE
Correcting path to plugins language folders

### DIFF
--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -109,16 +109,16 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 			{
 				// Take off core extensions containing a language folder
 				if ($extension != 'mod_version' && $extension != 'mod_multilangstatus' && $extension != 'protostar'
-					&& $extension != 'hathor' && $extension != 'isis' && $extension != 'beez3')
+					&& $extension != 'hathor' && $extension != 'isis' && $extension != 'beez3' && $extension != 'languagecode')
 				{
-					if (JFolder::exists("$path$extension$folder/language"))
+					if (JFolder::exists("$path$extension/language"))
 					{
 						// Scan extensions folder
-						$tags = JFolder::folders("$path$extension$folder/language");
+						$tags = JFolder::folders("$path$extension/language");
 
 						foreach ($tags as $tag)
 						{
-							$file = "$path$extension$folder/language/$tag/$tag.$prefix$extension$suffix.ini";
+							$file = "$path$extension/language/$tag/$tag.$prefix$extension$suffix.ini";
 
 							if (JFile::exists($file))
 							{


### PR DESCRIPTION
Although one may have translated and therefore saved in the global language folders a language file from a plugin language folder (patch first with https://github.com/joomla-projects/com_localise/pull/222 ), the files are not proposed to the choice when creating an extension package.

This PR solves the issue.
