### PR TITLE
Bug when using Import Specific Files

### DIFF
--- a/component/admin/controllers/package.php
+++ b/component/admin/controllers/package.php
@@ -152,7 +152,7 @@ class LocaliseControllerPackage extends JControllerForm
 	public function uploadOtherFile()
 	{
 		$app		= JFactory::getApplication();
-		$name		= $app->getUserState('com_localise.package.name');
+		$id			= $app->getUserState('com_localise.edit.package.id');
 		$model		= $this->getModel();
 		$upload		= $app->input->files->get('files');
 		$location	= $app->input->get('location');
@@ -175,7 +175,8 @@ class LocaliseControllerPackage extends JControllerForm
 			$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OTHER_FILE_UPLOAD'), 'error');
 		}
 
-		$url = 'index.php?option=com_localise&task=package.edit&cid[]=' . $name;
+		$url = 'index.php?option=com_localise&task=package.edit&cid[]=' . $id;
+
 		$this->setRedirect(JRoute::_($url, false));
 	}
 }

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -1084,10 +1084,18 @@ class LocaliseModelPackage extends JModelAdmin
 	{
 		jimport('joomla.filesystem.folder');
 
-		$app		= JFactory::getApplication();
-		$name		= $app->getUserState('com_localise.package.name');
-		$packPath	= JPATH_COMPONENT_ADMINISTRATOR . '/packages/' . $name . '.xml';
-		$xml		= simplexml_load_file($packPath);
+		$app	= JFactory::getApplication();
+		$id		= $app->getUserState('com_localise.edit.package.id');
+
+		if (is_array($id))
+		{
+			$id = $id[0];
+		}
+
+		$table = $this->getTable();
+		$table->load($id);
+
+		$xml = simplexml_load_file($table->path);
 
 		if ($xml)
 		{


### PR DESCRIPTION
Test: 
display Packages manager
Edit a core package for a language (not master).
Click on Import Specific Files
(you will have beforehand created somewhere a file called xx-XX.css)
Browse to pick this file and Import.

We get an error as $name is not found, therefore the xml can't be read.
Patch and test again. This time we are using the $id.
