### PR TITLE
Delete/rebuild database when deleting a language

### DIFF
--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 jimport('joomla.filesystem.file');
 jimport('joomla.client.helper');
 jimport('joomla.access.rules');
-require_once JPATH_COMPONENT . '/helpers/localise.php';
 
 /**
  * Language model.

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 jimport('joomla.filesystem.file');
 jimport('joomla.client.helper');
 jimport('joomla.access.rules');
+require_once JPATH_COMPONENT . '/helpers/localise.php';
 
 /**
  * Language model.
@@ -522,6 +523,9 @@ class LocaliseModelLanguage extends JModelAdmin
 			$data['tag'] = '';
 			$app->setUserState('com_localise.select', $data);
 		}
+
+		// Purge table to let it be rebuilt
+		LocaliseHelper::purge();
 
 		return true;
 	}


### PR DESCRIPTION
When we delete a language xx-XX.xml for s specific client in the languages manager and have created some translations for that language, these remain in the database, cluttering it as it is populated with all ini paths for that language and client.
This PR will purge the database when deleting a language, forcing the database to be repopulated in the managers.

To test, create an xx-XX.xml for site. Then save some translations for that language (no need to translate. In fact just displaying the translations manager for the language/client will create the rows in the db). Look the rows in the _localise table.
delete the language. Reload and look at the rows in the db.
