### PR TITLE
[fix] undefined index extension warning on php logs

### DIFF
--- a/component/admin/tables/localise.php
+++ b/component/admin/tables/localise.php
@@ -215,7 +215,7 @@ class LocaliseTableLocalise extends JTable
 	{
 		$fileName  = basename($this->path);
 		$fileInfo  = pathinfo($fileName);
-		$extension = $fileInfo['extension'];
+		$extension = isset($fileInfo['extension']) ? $fileInfo['extension'] : null;
 		$langTag   = $fileInfo['filename'];
 
 		// Make sure we are deleting a base language. Otherwise avoid to delete


### PR DESCRIPTION
This solves an issue that happens when clicking on purge on languages manager. Apparently the issue also happens elsewhere. The problem is that pathinfo does not set the `extension` index if the file does not have an extension as stated in the example #2 at [php.net](http://php.net/manual/en/function.pathinfo.php)
