### PR TITLE
Language file management improvements

### DIFF
--- a/component/admin/helpers/azuretranslator.php
+++ b/component/admin/helpers/azuretranslator.php
@@ -95,7 +95,7 @@ Class HTTPTranslator
 
 		try
 		{
-			require __DIR__ . '/azuretoken.php';
+			require_once __DIR__ . '/azuretoken.php';
 
 			// OAuth Url.
 			$authUrl = "https://datamarket.accesscontrol.windows.net/v2/OAuth2-13/";

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -42,7 +42,7 @@ class LocaliseLangFile
 	);
 
 	/**
-	 * Instnace of the file to read operations
+	 * Instance of the file to read operations
 	 *
 	 * @var  mixed  SplFileObject if fine | null otherwise
 	 */

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -124,7 +124,7 @@ class LocaliseLangFile
 	{
 		$lines = $this->getLines();
 
-		if (!$lines)
+		if (!($lines instanceof SplFileObject))
 		{
 			return false;
 		}

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -188,7 +188,7 @@ class LocaliseLangFile
 
 		$string = $lineParts[1];
 
-		if ($string[0] != '"' || $string[strlen($string) - 1] != '"')
+		if (strlen($string) < 2 || $string[0] != '"' || $string[strlen($string) - 1] != '"')
 		{
 			$this->addLineError($realNumber, 'Incorrect format');
 

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -368,7 +368,7 @@ class LocaliseLangFile
 	 *
 	 * @return  mixed  Array on success | FALSE otherwise
 	 */
-	public function getStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_RAW))
+	public function getStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_NORMAL))
 	{
 		if (null === $this->strings)
 		{
@@ -448,7 +448,7 @@ class LocaliseLangFile
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
-	protected function loadStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_RAW))
+	protected function loadStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_NORMAL))
 	{
 		$this->strings = false;
 
@@ -460,7 +460,7 @@ class LocaliseLangFile
 		}
 
 		$processSections = isset($options['process_sections']) ? $options['process_sections'] : false;
-		$scannerMode     = isset($options['scanner_mode']) ? $options['scanner_mode'] : INI_SCANNER_RAW;
+		$scannerMode     = isset($options['scanner_mode']) ? $options['scanner_mode'] : INI_SCANNER_NORMAL;
 
 		ini_set('track_errors', '1');
 		$this->strings = @parse_ini_string($content, $processSections, $scannerMode);

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -122,16 +122,16 @@ class LocaliseLangFile
 	 */
 	public function check()
 	{
-		$file = $this->getLines();
+		$lines = $this->getLines();
 
-		if (!$file)
+		if (!$lines)
 		{
 			return false;
 		}
 
 		$errors = 0;
 
-		foreach ($file as $lineNumber => $line)
+		foreach ($lines as $lineNumber => $line)
 		{
 			if (!$this->checkLine($lineNumber, $line))
 			{
@@ -416,7 +416,7 @@ class LocaliseLangFile
 	 */
 	protected function loadLines()
 	{
-		if (file_exists($this->filePath))
+		if ($this->isParseable())
 		{
 			$this->lines = new SplFileObject($this->filePath);
 		}

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -452,9 +452,9 @@ class LocaliseLangFile
 	{
 		$this->strings = false;
 
-		$content = $this->getContents();
+		$contents = $this->getContents();
 
-		if (false === $content)
+		if (false === $contents)
 		{
 			return $this;
 		}
@@ -462,8 +462,16 @@ class LocaliseLangFile
 		$processSections = isset($options['process_sections']) ? $options['process_sections'] : false;
 		$scannerMode     = isset($options['scanner_mode']) ? $options['scanner_mode'] : INI_SCANNER_NORMAL;
 
+		$contents = preg_replace_callback('/"(.*)"/', function ($matches) {
+					$result = '"' . str_replace('"', '\"', $matches[1]) . '"';
+
+					return $result;
+			},
+			$contents
+		);
+
 		ini_set('track_errors', '1');
-		$this->strings = @parse_ini_string($content, $processSections, $scannerMode);
+		$this->strings = @parse_ini_string($contents, $processSections, $scannerMode);
 
 		if (false === $this->strings)
 		{

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -1,0 +1,471 @@
+<?php
+/**
+ * @package     Com_Localise
+ * @subpackage  Lang
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+
+/**
+ * Language file
+ *
+ * @since  1.0
+ */
+class LocaliseLangFile
+{
+	/**
+	 * Word blacklist used to validate lines
+	 *
+	 * @var  mixed
+	 */
+	protected $blackList;
+
+	/**
+	 * Contents of the file
+	 *
+	 * @var  string
+	 */
+	protected $contents;
+
+	/**
+	 * Errors found
+	 *
+	 * @var  array
+	 */
+	protected $errors = array(
+		'global' => array(),
+		'lines'  => array()
+	);
+
+	/**
+	 * Lines of the file
+	 *
+	 * @var  mixed  SplFileObject if fine | null otherwise
+	 */
+	protected $lines;
+
+	/**
+	 * Path to the language file
+	 *
+	 * @var  string
+	 */
+	protected $filePath;
+
+	/**
+	 * File language strings
+	 *
+	 * @var  mixed  Array on parse success | FALSE on error
+	 */
+	protected $strings;
+
+	/**
+	 * Cached instances
+	 *
+	 * @var  array
+	 */
+	protected static $instances = array();
+
+	/**
+	 * Constructor
+	 *
+	 * @param   string  $filePath  Path to the language file
+	 *
+	 * @since   1.0
+	 */
+	public function __construct($filePath)
+	{
+		$this->filePath = trim($filePath);
+	}
+
+	/**
+	 * Add a global error
+	 *
+	 * @param   string  $errorMessage  Description of the error
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function addError($errorMessage)
+	{
+		array_push($this->errors['global'], $errorMessage);
+
+		return $this;
+	}
+
+	/**
+	 * Add error found in a line
+	 *
+	 * @param   integer  $lineNumber    Line failing
+	 * @param   string   $errorMessage  Description of the error
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function addLineError($lineNumber, $errorMessage)
+	{
+		if (!isset($this->errors['lines'][$lineNumber]))
+		{
+			$this->errors['lines'][$lineNumber] = array();
+		}
+
+		array_push($this->errors['lines'][$lineNumber], $errorMessage);
+
+		return $this;
+	}
+
+	/**
+	 * Check that file has no errors
+	 *
+	 * @return  boolean
+	 */
+	public function check()
+	{
+		$file = $this->getLines();
+
+		if (!$file)
+		{
+			return false;
+		}
+
+		$errors = 0;
+
+		foreach ($file as $lineNumber => $line)
+		{
+			if (!$this->checkLine($lineNumber, $line))
+			{
+				++$errors;
+			}
+		}
+
+		return $errors ? false : true;
+	}
+
+	/**
+	 * Check the format of one line of the file
+	 *
+	 * @param   integer  $lineNumber  Number of the line being validated
+	 * @param   string   $line        Line contents
+	 *
+	 * @return  boolean
+	 */
+	protected function checkLine($lineNumber, $line)
+	{
+		// Avoid BOM error as BOM is OK when using parse_ini.
+		if ($lineNumber == 0)
+		{
+			$line = str_replace("\xEF\xBB\xBF", '', $line);
+		}
+
+		$line = trim($line);
+
+		// Ignore comment lines.
+		if (!strlen($line) || $line['0'] == ';')
+		{
+			return true;
+		}
+
+		// Ignore grouping tag lines, like: [group]
+		if (preg_match('#^\[[^\]]*\](\s*;.*)?$#', $line))
+		{
+			return true;
+		}
+
+		$realNumber = $lineNumber + 1;
+
+		// Check that string does not begin or end with "_QQ_"
+		$checkLine = str_replace('"_QQ_"', 'QQQQQ', $line);
+
+		$lineParts = explode('=', $checkLine, 2);
+
+		if (count($lineParts) != 2)
+		{
+			$this->addLineError($realNumber, 'Incorrect format');
+
+			return false;
+		}
+
+		$string = $lineParts[1];
+
+		if ($string[0] != '"' || $string[strlen($string) - 1] != '"')
+		{
+			$this->addLineError($realNumber, 'Incorrect format');
+
+			return false;
+		}
+
+		// Remove the "_QQ_" from the equation
+		$line = str_replace('"_QQ_"', '', $line);
+
+		// Check for any incorrect uses of _QQ_.
+		if (strpos($line, '_QQ_') !== false)
+		{
+			$this->addLineError($realNumber, 'Invalid use of _QQ_');
+
+			return false;
+		}
+
+		// Check for odd number of double quotes.
+		if (substr_count($line, '"') % 2 != 0)
+		{
+			$this->addLineError($realNumber, 'Odd number of double quotes');
+
+			return false;
+		}
+
+		// Check that the line passes the necessary format.
+		if (!preg_match('#^[A-Z][A-Z0-9_\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
+		{
+			$this->addLineError($realNumber, 'Incorrect format');
+
+			return false;
+		}
+
+		// Check that the key is not in the blacklist.
+		$key = strtoupper(trim(substr($line, 0, strpos($line, '='))));
+
+		if (in_array($key, $this->getBlackList()))
+		{
+			$this->addLineError($realNumber, 'Key in blackList');
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the blackList
+	 *
+	 * @return  array
+	 */
+	public function getBlackList()
+	{
+		if (null === $this->blackList)
+		{
+			$this->loadDefaultBlackList();
+		}
+
+		return $this->blackList;
+	}
+
+	/**
+	 * Get the contents of the file
+	 *
+	 * @return  mixed  String on success | FALSE otherwise
+	 */
+	public function getContents()
+	{
+		if (null === $this->contents)
+		{
+			$this->loadContents();
+		}
+
+		return $this->contents;
+	}
+
+	/**
+	 * Get last error encountered
+	 *
+	 * @return  string
+	 */
+	public function getLastError()
+	{
+		return end($this->errors['global']);
+	}
+
+	/**
+	 * Get all the errors encountered
+	 *
+	 * @return  array
+	 */
+	public function getErrors()
+	{
+		return $this->errors['global'];
+	}
+
+	/**
+	 * Get the lines errors
+	 *
+	 * @return  array
+	 */
+	public function getLinesErrors()
+	{
+		return $this->errors['lines'];
+	}
+
+	/**
+	 * Create and return a cached instance
+	 *
+	 * @param   string  $filePath  Path to the language file
+	 *
+	 * @return  LocaliseLangFile
+	 */
+	public static function getInstance($filePath)
+	{
+		if (empty(static::$instances[$filePath]))
+		{
+			static::$instances[$filePath] = new static($filePath);
+		}
+
+		return static::$instances[$filePath];
+	}
+
+	/**
+	 * Get an instance of SplFileObject
+	 *
+	 * @return  mixed  SplFileObject on success | null otherwise
+	 */
+	public function getLines()
+	{
+		if (null === $this->lines)
+		{
+			$this->loadLines();
+		}
+
+		return $this->lines;
+	}
+
+	/**
+	 * Get a language string
+	 *
+	 * @param   string  $key  Key of the language string
+	 *
+	 * @return  mixed  String on success | null otherwise
+	 */
+	public function getString($key)
+	{
+		$strings = $this->getStrings();
+
+		if ($strings && isset($strings[$key]))
+		{
+			return $strings[$key];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the file language strings
+	 *
+	 * @return  mixed  Array on success | FALSE otherwise
+	 */
+	public function getStrings()
+	{
+		if (null === $this->strings)
+		{
+			$this->loadStrings();
+		}
+
+		return $this->strings;
+	}
+
+	/**
+	 * Fast check to see if the file is parseable with parse_ini_string
+	 *
+	 * @return  boolean
+	 */
+	public function isParseable()
+	{
+		if (empty($this->filePath) || !file_exists($this->filePath))
+		{
+			$this->addError('File not parseable (' . $this->filePath . '): File does not exist');
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Load the file contents with file_get_contents
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function loadContents()
+	{
+		$this->contents = false;
+
+		if (!$this->isParseable())
+		{
+			return $this;
+		}
+
+		$this->contents = file_get_contents($this->filePath);
+
+		return $this;
+	}
+
+	/**
+	 * Load the default blacklist from Joomla
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function loadDefaultBlackList()
+	{
+		$this->blackList = array('YES', 'NO', 'NULL', 'FALSE', 'ON', 'OFF', 'NONE', 'TRUE');
+
+		return $this;
+	}
+
+	/**
+	 * Method to load the file contents
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function loadLines()
+	{
+		if (file_exists($this->filePath))
+		{
+			$this->lines = new SplFileObject($this->filePath);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Load the file language strings
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	protected function loadStrings()
+	{
+		$this->strings = false;
+
+		$content = $this->getContents();
+
+		if (false === $content)
+		{
+			return $this;
+		}
+
+		$content = str_replace('_QQ_', '"\""', $content);
+
+		ini_set('track_errors', '1');
+		$this->strings = @parse_ini_string($content);
+
+		if (false === $this->strings)
+		{
+			$error = isset($php_errormsg) ? $php_errormsg : '';
+
+			$this->addError("Error parsing file contents of " . $this->filePath . ": " . $error);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method to override the blackList
+	 *
+	 * @param   array  $blackList  Array with the desired black list words
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	public function setBlackList($blackList = array())
+	{
+		$this->blackList = $blackList;
+
+		return $this;
+	}
+}

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -42,11 +42,11 @@ class LocaliseLangFile
 	);
 
 	/**
-	 * Lines of the file
+	 * Instnace of the file to read operations
 	 *
 	 * @var  mixed  SplFileObject if fine | null otherwise
 	 */
-	protected $lines;
+	protected $file;
 
 	/**
 	 * Path to the language file
@@ -122,22 +122,24 @@ class LocaliseLangFile
 	 */
 	public function check()
 	{
-		$lines = $this->getLines();
+		$file = $this->getFile();
 
-		if (!($lines instanceof SplFileObject))
+		if (!($file instanceof SplFileObject))
 		{
 			return false;
 		}
 
 		$errors = 0;
 
-		foreach ($lines as $lineNumber => $line)
+		foreach ($file as $lineNumber => $line)
 		{
 			if (!$this->checkLine($lineNumber, $line))
 			{
 				++$errors;
 			}
 		}
+
+		$this->destroyFile();
 
 		return $errors ? false : true;
 	}
@@ -236,6 +238,18 @@ class LocaliseLangFile
 	}
 
 	/**
+	 * To avoid unclosed files ensure that the file is destroyed
+	 *
+	 * @return  LocaliseLangFile  Self instance for chaining
+	 */
+	public function destroyFile()
+	{
+		$this->file = null;
+
+		return $this;
+	}
+
+	/**
 	 * Get the blackList
 	 *
 	 * @return  array
@@ -314,17 +328,18 @@ class LocaliseLangFile
 
 	/**
 	 * Get an instance of SplFileObject
+	 * WARNING: Remember to use destroyFile() to avoid file collissions
 	 *
 	 * @return  mixed  SplFileObject on success | null otherwise
 	 */
-	public function getLines()
+	public function getFile()
 	{
-		if (null === $this->lines)
+		if (null === $this->file)
 		{
-			$this->loadLines();
+			$this->loadFile();
 		}
 
-		return $this->lines;
+		return $this->file;
 	}
 
 	/**
@@ -410,15 +425,15 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Method to load the file contents
+	 * Method to load an instance of SplFileObject to read the file
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
-	protected function loadLines()
+	protected function loadFile()
 	{
 		if ($this->isParseable())
 		{
-			$this->lines = new SplFileObject($this->filePath);
+			$this->file = new SplFileObject($this->filePath);
 		}
 
 		return $this;

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -250,18 +250,6 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Callback for preg_replace_callback to escape double quotes inside language strings.
-	 *
-	 * @param   array  $matches  Array of strings that match with the regular expression
-	 *
-	 * @return  string
-	 */
-	private function escapeQuotes($matches)
-	{
-		return '"' . str_replace('"', '\"', $matches[1]) . '"';
-	}
-
-	/**
 	 * Get the blackList.
 	 *
 	 * @return  array
@@ -503,7 +491,12 @@ class LocaliseLangFile
 	 */
 	protected function prepareContents($contents)
 	{
-		return preg_replace_callback('/"(.*)"/', array($this, 'escapeQuotes'), $contents);
+		$strings = array(
+			'\"'     => '\\\"',
+			'"_QQ_"' => '\"_QQ_\"'
+		);
+
+		return strtr($contents, $strings);
 	}
 
 	/**

--- a/component/admin/lang/file.php
+++ b/component/admin/lang/file.php
@@ -18,21 +18,21 @@ defined('_JEXEC') or die;
 class LocaliseLangFile
 {
 	/**
-	 * Word blacklist used to validate lines
+	 * Word blacklist used to validate lines.
 	 *
 	 * @var  mixed
 	 */
 	protected $blackList;
 
 	/**
-	 * Contents of the file
+	 * Contents of the file.
 	 *
 	 * @var  string
 	 */
 	protected $contents;
 
 	/**
-	 * Errors found
+	 * Errors found.
 	 *
 	 * @var  array
 	 */
@@ -42,35 +42,35 @@ class LocaliseLangFile
 	);
 
 	/**
-	 * Instance of the file to read operations
+	 * Instance of the file to read operations.
 	 *
 	 * @var  mixed  SplFileObject if fine | null otherwise
 	 */
 	protected $file;
 
 	/**
-	 * Path to the language file
+	 * Path to the language file.
 	 *
 	 * @var  string
 	 */
 	protected $filePath;
 
 	/**
-	 * File language strings
+	 * File language strings.
 	 *
 	 * @var  mixed  Array on parse success | FALSE on error
 	 */
 	protected $strings;
 
 	/**
-	 * Cached instances
+	 * Cached instances.
 	 *
 	 * @var  array
 	 */
 	protected static $instances = array();
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @param   string  $filePath  Path to the language file
 	 *
@@ -82,7 +82,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Add a global error
+	 * Add a global error.
 	 *
 	 * @param   string  $errorMessage  Description of the error
 	 *
@@ -96,7 +96,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Add error found in a line
+	 * Add error found in a line.
 	 *
 	 * @param   integer  $lineNumber    Line failing
 	 * @param   string   $errorMessage  Description of the error
@@ -116,7 +116,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Check that file has no errors
+	 * Check that file has no errors.
 	 *
 	 * @return  boolean
 	 */
@@ -145,7 +145,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Check the format of one line of the file
+	 * Check the format of one line of the file.
 	 *
 	 * @param   integer  $lineNumber  Number of the line being validated
 	 * @param   string   $line        Line contents
@@ -238,7 +238,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * To avoid unclosed files ensure that the file is destroyed
+	 * To avoid unclosed files ensure that the file is destroyed.
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
@@ -250,7 +250,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get the blackList
+	 * Get the blackList.
 	 *
 	 * @return  array
 	 */
@@ -265,7 +265,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get the contents of the file
+	 * Get the contents of the file.
 	 *
 	 * @return  mixed  String on success | FALSE otherwise
 	 */
@@ -280,7 +280,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get last error encountered
+	 * Get last error encountered.
 	 *
 	 * @return  string
 	 */
@@ -290,7 +290,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get all the errors encountered
+	 * Get all the errors encountered.
 	 *
 	 * @return  array
 	 */
@@ -300,7 +300,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get the lines errors
+	 * Get the lines errors.
 	 *
 	 * @return  array
 	 */
@@ -310,7 +310,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Create and return a cached instance
+	 * Create and return a cached instance.
 	 *
 	 * @param   string  $filePath  Path to the language file
 	 *
@@ -327,7 +327,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get an instance of SplFileObject
+	 * Get an instance of SplFileObject.
 	 * WARNING: Remember to use destroyFile() to avoid file collissions
 	 *
 	 * @return  mixed  SplFileObject on success | null otherwise
@@ -343,7 +343,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get a language string
+	 * Get a language string.
 	 *
 	 * @param   string  $key  Key of the language string
 	 *
@@ -362,22 +362,24 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Get the file language strings
+	 * Get the file language strings.
+	 *
+	 * @param   array  $options  Parsing options
 	 *
 	 * @return  mixed  Array on success | FALSE otherwise
 	 */
-	public function getStrings()
+	public function getStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_RAW))
 	{
 		if (null === $this->strings)
 		{
-			$this->loadStrings();
+			$this->loadStrings($options);
 		}
 
 		return $this->strings;
 	}
 
 	/**
-	 * Fast check to see if the file is parseable with parse_ini_string
+	 * Fast check to see if the file is parseable with parse_ini_string.
 	 *
 	 * @return  boolean
 	 */
@@ -394,7 +396,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Load the file contents with file_get_contents
+	 * Load the file contents with file_get_contents.
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
@@ -413,7 +415,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Load the default blacklist from Joomla
+	 * Load the default blacklist from Joomla.
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
@@ -425,7 +427,7 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Method to load an instance of SplFileObject to read the file
+	 * Method to load an instance of SplFileObject to read the file.
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
@@ -440,11 +442,13 @@ class LocaliseLangFile
 	}
 
 	/**
-	 * Load the file language strings
+	 * Load the file language strings.
+	 *
+	 * @param   array  $options  Parsing options
 	 *
 	 * @return  LocaliseLangFile  Self instance for chaining
 	 */
-	protected function loadStrings()
+	protected function loadStrings($options = array('process_sections' => false, 'scanner_mode' => INI_SCANNER_RAW))
 	{
 		$this->strings = false;
 
@@ -455,10 +459,11 @@ class LocaliseLangFile
 			return $this;
 		}
 
-		$content = str_replace('_QQ_', '"\""', $content);
+		$processSections = isset($options['process_sections']) ? $options['process_sections'] : false;
+		$scannerMode     = isset($options['scanner_mode']) ? $options['scanner_mode'] : INI_SCANNER_RAW;
 
 		ini_set('track_errors', '1');
-		$this->strings = @parse_ini_string($content);
+		$this->strings = @parse_ini_string($content, $processSections, $scannerMode);
 
 		if (false === $this->strings)
 		{

--- a/component/admin/layouts/field/key/input.php
+++ b/component/admin/layouts/field/key/input.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
-
 extract($displayData);
 
 /**
@@ -78,4 +76,4 @@ $safeReference = htmlspecialchars($element['description'], ENT_NOQUOTES, 'UTF-8'
 	<textarea id="<?php echo $id; ?>-reference" style="display: none;"><?php echo $safeReference; ?></textarea>
 	<textarea id="<?php echo $id; ?>-original" style="display: none;"><?php echo $safeValue; ?></textarea>
 <?php endif; ?>
-<textarea <?php echo ArrayHelper::toString($attributes); ?> ><?php echo $safeValue; ?></textarea>
+<textarea <?php echo JArrayHelper::toString($attributes); ?> ><?php echo $safeValue; ?></textarea>

--- a/component/admin/layouts/field/key/input.php
+++ b/component/admin/layouts/field/key/input.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Utilities\ArrayHelper;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * ------------------
+ * @param   boolean           $autofocus             Autofocus on this field
+ * @param   string            $class                 CSS class to apply
+ * @param   boolean           $debug                 Is debug enabled for this field?
+ * @param   string            $description           Description text of the field
+ * @param   boolean           $disabled              Does this field need to be disabled?
+ * @param   SimpleXMLElement  $element               The object of the <field /> XML element that describes the form field.
+ * @param   JFormField        $field                 Object to access to the field properties
+ * @param   boolean           $hidden                Hidden attribute of the field
+ * @param   boolean           $hiddenLabel           Do we want to hide label?
+ * @param   string            $hint                  Field hint
+ * @param   string            $id                    DOM id of the element
+ * @param   string            $label                 Label text of the field
+ * @param   boolean           $multiple              Allow to enter multiple values?
+ * @param   string            $name                  Name of the field to display
+ * @param   string            $onchange              onchange attribute of the field
+ * @param   string            $onclick               onclick attribute of the field
+ * @param   boolean           $readonly              Do not allow to modify field value
+ * @param   boolean           $required              Is this field required?
+ * @param   integer           $size                  Size for the input element
+ * @param   mixed             $value                 Value of the field
+ *
+ */
+
+JHtml::_('jquery.framework');
+JHtml::_('script', 'media/com_localise/js/field-key.js', false, false, false, false);
+
+$attributes = array();
+
+$status = (string) $element['status'];
+$statusClass = ($value == '' ? 'untranslated' : ($value == $element['description'] ? $status : 'translated'));
+
+// Manually handled attributes
+$attributes['data-status']   = $statusClass;
+$attributes['class']         = trim($class . ' js-localise-field-translation width-45 ' . $statusClass);
+$attributes['id']            = $id;
+$attributes['name']          = $name;
+$attributes['readonly']      = $readonly ? 'readonly' : null;
+$attributes['disabled']      = $disabled ? 'disabled' : null;
+$attributes['required']      = $required ? 'required' : null;
+$attributes['aria-required'] = $required ? 'true' : null;
+$attributes['onchange']      = $onchange ? (string) $onchange : null;
+$attributes['placeholder']   = $hint;
+
+// Clean null attributes
+foreach ($attributes as $attributeName => $attributeValue)
+{
+	if (null === $attributeValue)
+	{
+		unset($attributes[$attributeName]);
+	}
+}
+
+$safeValue     = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
+$safeReference = htmlspecialchars($element['description'], ENT_NOQUOTES, 'UTF-8');
+?>
+
+<?php if ($status != 'extra') : ?>
+	<i class="icon-reset hasTooltip pointer js-localise-btn-import" data-import="<?php echo $id; ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATION_INSERT'); ?>"></i>
+	<i class="icon-translate-bing hasTooltip pointer js-localise-btn-translate" data-translate="<?php echo $id; ?>" data-token="<?php echo JSession::getFormToken(); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATION_AZURE'); ?>" ></i>
+	<textarea id="<?php echo $id; ?>-reference" style="display: none;"><?php echo $safeReference; ?></textarea>
+	<textarea id="<?php echo $id; ?>-original" style="display: none;"><?php echo $safeValue; ?></textarea>
+<?php endif; ?>
+<textarea <?php echo ArrayHelper::toString($attributes); ?> ><?php echo $safeValue; ?></textarea>

--- a/component/admin/layouts/field/key/input.php
+++ b/component/admin/layouts/field/key/input.php
@@ -66,8 +66,8 @@ foreach ($attributes as $attributeName => $attributeValue)
 	}
 }
 
-$safeValue     = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
-$safeReference = htmlspecialchars($element['description'], ENT_NOQUOTES, 'UTF-8');
+$safeValue     = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+$safeReference = htmlspecialchars($element['description'], ENT_COMPAT, 'UTF-8');
 ?>
 
 <?php if ($status != 'extra') : ?>

--- a/component/admin/layouts/field/key/label.php
+++ b/component/admin/layouts/field/key/label.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ * 	$text         : (string)  The label text
+ * 	$description  : (string)  An optional description to use in a tooltip
+ * 	$for          : (string)  The id of the input this label is for
+ * 	$required     : (boolean) True if a required field
+ * 	$classes      : (array)   A list of classes
+ * 	$position     : (string)  The tooltip position. Bottom for alias
+ */
+
+$text		= $displayData['text'];
+$desc		= $displayData['description'];
+$for		= $displayData['for'];
+$req		= $displayData['required'];
+$classes	= array_filter((array) $displayData['classes']);
+$position	= $displayData['position'];
+
+$id = $for . '-lbl';
+$title = '';
+
+// If a description is specified, use it to build a tooltip.
+if (!empty($desc))
+{
+	JHtml::_('bootstrap.tooltip');
+	$classes[] = 'hasTooltip';
+	$title = ' title="' . JHtml::tooltipText(trim($text, ':'), $desc, 0) . '"';
+}
+
+// If required, there's a class for that.
+if ($req)
+{
+	$classes[] = 'required';
+}
+
+?>
+<label id="<?php echo $id; ?>" for="<?php echo $for; ?>" class="<?php echo implode(' ', $classes); ?>"<?php echo $title; ?><?php echo $position; ?>>
+	<?php echo $text; ?><?php if ($req) : ?><span class="star">&#160;*</span><?php endif; ?>
+</label>

--- a/component/admin/layouts/field/key/label.php
+++ b/component/admin/layouts/field/key/label.php
@@ -30,14 +30,6 @@ $position	= $displayData['position'];
 $id = $for . '-lbl';
 $title = '';
 
-// If a description is specified, use it to build a tooltip.
-if (!empty($desc))
-{
-	JHtml::_('bootstrap.tooltip');
-	$classes[] = 'hasTooltip';
-	$title = ' title="' . JHtml::tooltipText(trim($text, ':'), $desc, 0) . '"';
-}
-
 // If required, there's a class for that.
 if ($req)
 {

--- a/component/admin/localise.php
+++ b/component/admin/localise.php
@@ -15,6 +15,9 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_localise'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
+// Register component prefix
+JLoader::registerPrefix('Localise', __DIR__);
+
 // Include helper files
 require_once JPATH_COMPONENT . '/helpers/defines.php';
 require_once JPATH_COMPONENT . '/helpers/localise.php';

--- a/component/admin/models/fields/key.php
+++ b/component/admin/models/fields/key.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-jimport('joomla.form.formfield');
-
 /**
  * Form Field Key class.
  *
@@ -29,24 +27,18 @@ class JFormFieldKey extends JFormField
 	protected $type = 'Key';
 
 	/**
-	 * Method to get the field label.
+	 * Layout to render the label
 	 *
-	 * @return  string    The field label.
+	 * @var  string
 	 */
+	protected $renderLabelLayout = 'field.key.label';
 
 	/**
-	 * Method to get the field label markup.
+	 * Layout to render the field input
 	 *
-	 * @return  string  The field label markup.
-	 *
-	 * @since  1.6
+	 * @var  string
 	 */
-	protected function getLabel()
-	{
-		return '<label id="' . $this->id . '-lbl" for="' . $this->id . '">'
-					. $this->element['label']
-				. '</label>';
-	}
+	protected $inputLayout = 'field.key.input';
 
 	/**
 	 * Method to get the field input.
@@ -55,83 +47,61 @@ class JFormFieldKey extends JFormField
 	 */
 	protected function getInput()
 	{
-		// Set the class for the label.
-		$class = !empty($this->descText) ? 'key-label hasTooltip fltrt' : 'key-label fltrt';
+		return JLayoutHelper::render($this->getInputLayout(), $this->getLayoutData());
+	}
 
-		// If a description is specified, use it to build a tooltip.
-		if (!empty($this->descText))
-		{
-			$label = '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '" title="'
-					. htmlspecialchars(htmlspecialchars('::' . str_replace("\n", "\\n", $this->descText), ENT_QUOTES, 'UTF-8')) . '">';
-		}
-		else
-		{
-			$label = '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '">';
-		}
+	/**
+	 * Method to get the layout to use to render the field input
+	 *
+	 * @return  string
+	 */
+	protected function getInputLayout()
+	{
+		return !empty($this->element['layout']) ? (string) $this->element['layout'] : $this->inputLayout;
+	}
 
-		JText::script('COM_LOCALISE_LABEL_TRANSLATION_GOOGLE_ERROR');
-		$label .= $this->element['label'] . 'br />' . $this->element['description'];
-		$label .= '</label>';
-		$status = (string) $this->element['status'];
+	/**
+	 * Get the data that is going to be passed to the layout
+	 *
+	 * @return  array
+	 */
+	protected function getLayoutData()
+	{
+		// Label preprocess
+		$label = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
+		$label = $this->translateLabel ? JText::_($label) : $label;
 
-		if ($status == 'extra')
-		{
-			$onclick = '';
-			$button  = '<span style="width:5%;">'
-						. JHtml::_('image', 'com_localise/icon-16-arrow-gray.png', '', array('class' => 'pointer'), true) . '</span>';
+		// Description preprocess
+		$description = !empty($this->description) ? $this->description : null;
+		$description = !empty($description) && $this->translateDescription ? JText::_($description) : $description;
 
-			$onclick2 = '';
-			$button2  = '<span style="width:5%;">'
-						. JHtml::_('image', 'com_localise/icon-16-bing-gray.png', '', array('class' => 'pointer'), true) . '</span>';
-		}
-		else
-		{
-			$onclick = "javascript:document.id(
-						'" . $this->id . "'
-						)
-						.set(
-						'value','" . addslashes(htmlspecialchars($this->element['description'], ENT_COMPAT, 'UTF-8')) . "'
-						);
-						if (document.id('" . $this->id . "').get('value')=='') {document.id('" . $this->id . "').set('class','width-45 untranslated');}
-						else {document.id('" . $this->id . "').set('class','width-45 " . ($status == 'untranslated' ? 'unchanged' : $status) . "');}";
-			$button  = '<i class="icon-reset hasTooltip return pointer" title="' . JText::_('COM_LOCALISE_TOOLTIP_TRANSLATION_INSERT')
-						. '" onclick="' . $onclick . '"></i>';
-			/* $onclick2 = "javascript:if (typeof(google) !== 'undefined') {
-			var translation='" . addslashes(htmlspecialchars($this->element['description'], ENT_COMPAT, 'UTF-8')) . "';
-				translation=translation.replace('%s','___s');translation=translation.replace('%d','___d');
-				translation=translation.replace(/%([0-9]+)\\\$s/,'___\$1');google.language.translate(translation,
-				Localise.language_src, Localise.language_dest, function(result) {if (result.translation) {
-			  translation = result.translation;
-			  translation = translation.replace('___s','%s');
-			  translation = translation.replace('___d','%d');
-			  translation = translation.replace(/___([0-9]+)/,'%$1\$s');
-			  document.id('" . $this->id . "').set('value',translation);
-			  if (document.id('" . $this->id . "').get('value')=='" . addslashes(htmlspecialchars($this->element['description'], ENT_COMPAT, 'UTF-8'))
-				. "') document.id('" . $this->id . "').set('class','width-45 unchanged');
-				else document.id('" . $this->id . "').set('class','width-45 translated');}
-				else alert(Joomla.JText._('COM_LOCALISE_LABEL_TRANSLATION_GOOGLE_ERROR'));});}
-				else alert(Joomla.JText._('COM_LOCALISE_LABEL_TRANSLATION_GOOGLE_ERROR'));";
-			  $button2 = '<span style="width:5%;">' . JHtml::_('image', 'com_localise/icon-16-google.png', '',
-				array('title' => JText::_('COM_LOCALISE_TOOLTIP_TRANSLATION_GOOGLE'), 'class' => 'hasTooltip pointer',
-				'onclick' => $onclick2), true) . '</span>';
-			  */
-			$token    = JSession::getFormToken();
-			$onclick2 = "javascript:AzureTranslator(this, [], 0, '$token');";
-			$button2  = '<input type="hidden" id="' . $this->id . 'text" value=\''
-						. addslashes(htmlspecialchars($this->element['description'], ENT_COMPAT, 'UTF-8')) . '\' />';
-			$button2 .= '<i class="icon-translate-bing hasTooltip translate pointer" title="'
-						. JText::_('COM_LOCALISE_TOOLTIP_TRANSLATION_AZURE') . '" onclick="' . $onclick2 . '" rel="' . $this->id . '"></i>';
-		}
+		$hiddenLabel = empty($options['hiddenLabel']) && $this->getAttribute('hiddenLabel');
 
-		$onkeyup = "javascript:";
-		$onkeyup .= "if (this.get('value')=='') {this.set('class','width-45 untranslated');}
-					else {if (this.get('value')=='" . addslashes(htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'))
-					. "') this.set('class','width-45 " . $status . "');
-					" . ($status == 'extra' ? "else this.set('class','width-45 extra');}" : "else this.set('class','width-45 translated');}");
-		$input = '<textarea name="' . $this->name . '" id="' . $this->id . '" onfocus="this.select()" class="width-45 ' . ($this->value == '' ?
-					'untranslated' : ($this->value == $this->element['description'] ? $status : 'translated')) . '" onkeyup="'
-					. $onkeyup . '">' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '</textarea>';
+		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
 
-		return $button . $button2 . $input;
+		$debug    = !empty($this->element['debug']) ? ((string) $this->element['debug'] === 'true') : false;
+
+		return array(
+			'autofocus'   => $this->autofocus,
+			'class'       => trim($this->class . ' form-field'),
+			'debug'       => $debug,
+			'description' => $description,
+			'disabled'    => $this->disabled,
+			'element'     => $this->element,
+			'field'       => $this,
+			'hidden'      => $this->hidden,
+			'hiddenLabel' => $hiddenLabel,
+			'hint'        => $hint,
+			'id'          => $this->id,
+			'label'       => $label,
+			'multiple'    => $this->multiple,
+			'name'        => $this->name,
+			'onchange'    => $this->onchange,
+			'onclick'     => $this->onclick,
+			'readonly'    => $this->readonly,
+			'required'    => $this->required,
+			'size'        => $this->size,
+			'value'       => $this->value
+		);
 	}
 }

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -643,6 +643,7 @@ class LocaliseModelTranslation extends JModelAdmin
 						$field      = $fieldset->addChild('field');
 						$string     = $refsections['keys'][$key];
 						$translated = isset($sections['keys'][$key]);
+
 						$modified   = $translated && $sections['keys'][$key] != $refsections['keys'][$key];
 						$status     = $modified
 							? 'translated'
@@ -936,13 +937,15 @@ class LocaliseModelTranslation extends JModelAdmin
 
 			while (!$stream->eof())
 			{
+				$line = $stream->gets();
+
 				if (preg_match('/^([A-Z][A-Z0-9_\-\.]*)\s*=/', $line, $matches))
 				{
 					$key = $matches[1];
 
 					if (isset($strings[$key]))
 					{
-						$contents[] = $key . '="' . str_replace('"', '"_QQ_"', $strings[$key]) . "\"\n";
+						$contents[] = $key . '="' . $strings[$key] . "\"\n";
 						unset($strings[$key]);
 					}
 				}
@@ -950,8 +953,6 @@ class LocaliseModelTranslation extends JModelAdmin
 				{
 					$contents[] = $line;
 				}
-
-				$line = $stream->gets();
 			}
 
 			if (!empty($strings))
@@ -960,7 +961,7 @@ class LocaliseModelTranslation extends JModelAdmin
 
 				foreach ($strings as $key => $string)
 				{
-					$contents[] = $key . '="' . str_replace('"', '"_QQ_"', $string) . "\"\n";
+					$contents[] = $key . '="' . $string . "\"\n";
 				}
 			}
 

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -215,11 +215,11 @@ class LocaliseModelTranslation extends JModelAdmin
 					$params             = JComponentHelper::getParams('com_localise');
 					$isTranslationsView = JFactory::getApplication()->input->get('view') == 'translations';
 
-					$lines = $langFile->getLines();
+					$file = $langFile->getFile();
 
-					if ($lines)
+					if ($file)
 					{
-						foreach ($lines as $lineNumber => $line)
+						foreach ($file as $lineNumber => $line)
 						{
 							if (!strlen(trim($line)))
 							{
@@ -359,6 +359,8 @@ class LocaliseModelTranslation extends JModelAdmin
 					{
 						$this->item->additionalcopyright[] = $params->get('additionalcopyright');
 					}
+
+					$langFile->destroyFile();
 
 					if (!$langFile->check())
 					{

--- a/component/admin/models/translator.php
+++ b/component/admin/models/translator.php
@@ -34,7 +34,7 @@ class LocaliseModelTranslator extends JModelLegacy
 		{
 			$this->setError(JText::_('COM_LOCALISE_MISSING_CLIENTID_SECRET'));
 
-			return '';
+			return false;
 		}
 
 		$app  = JFactory::getApplication();
@@ -44,7 +44,7 @@ class LocaliseModelTranslator extends JModelLegacy
 		{
 			$this->setError(JText::_('COM_LOCALISE_MISSING_TEXT'));
 
-			return '';
+			return false;
 		}
 
 		$to = $app->input->getCmd('to');
@@ -53,7 +53,7 @@ class LocaliseModelTranslator extends JModelLegacy
 		{
 			$this->setError(JText::_('COM_LOCALISE_MISSING_TO_LANGUAGECODE'));
 
-			return '';
+			return false;
 		}
 
 		$from = $app->input->getCmd('from');

--- a/component/admin/views/translation/tmpl/edit.php
+++ b/component/admin/views/translation/tmpl/edit.php
@@ -69,59 +69,56 @@ $ftpSets   = $this->formftp->getFieldsets();
 JText::script('COM_LOCALISE_BINGTRANSLATING_NOW');
 ?>
 <script type="text/javascript">
-	var bingTranslateComplete = false, translator;
+	var translator;
 	var Localise = {};
 	Localise.language_src = '<?php echo $src; ?>';
 	Localise.language_dest = '<?php echo $dest; ?>';
 
 	function AzureTranslator(obj, targets, i, token, transUrl){
-		var idname = jQuery(obj).attr('rel');
-		if(translator && !translator.status){
-			alert(Joomla.JText._('COM_LOCALISE_BINGTRANSLATING_NOW'));
-			return;
-		}
+		var targetSelector = '#' + jQuery(obj).attr('data-translate'),
+			targetField = jQuery(targetSelector),
+			referenceSelector = targetSelector + '-reference',
+			referenceField = jQuery(referenceSelector);
+
+		targetField.attr('disabled', 'disabled').css('opacity', '0.4');
 
 		translator =jQuery.ajax({
 			type:'POST',
-			uril:'index.php',
-			data:'option=com_localise&view=translator&format=json&id=<?php echo $this->form->getValue('id');?>&from=<?php echo $src;?>&to=<?php echo $dest;?>&text='+encodeURI(jQuery('#'+idname+'text').val())+'&'+token+'=1',
+			url:'index.php?' + token + '=1',
+			data : {
+				option : 'com_localise',
+				view   : 'translator',
+				format : 'json',
+				id     : '<?php echo $this->form->getValue("id");?>',
+				from   : '<?php echo $src;?>',
+				to     : '<?php echo $dest;?>',
+				text   : referenceField.val()
+			},
 			dataType:'json',
 			success:function(res){
 				if(res.success){
-					jQuery('#'+idname).val(res.text);
-				}
-				if(targets && targets.length > (i+1)){
-					AzureTranslator(targets[i+1], targets, i+1, token);
-					jQuery('html,body').animate({scrollTop:jQuery(targets[i+1]).offset().top-150}, 0);
+					targetField.val(res.text);
 				} else {
-					bingTranslateComplete = false;
-					if(targets.length > 1)
-						jQuery('html,body').animate({scrollTop:0}, 0);
+					alert(res.text);
 				}
+
+				targetField.removeAttr('disabled').css('opacity', '1').trigger('focusout');
 			}
 		});
 	}
 
 	function returnAll()
 	{
-		$$('i.return').each(function(e){
-			if(e.click)
-				e.click();
-			else
-				e.onclick();
+		jQuery('i.js-localise-btn-reset').each(function(e){
+			jQuery(this).trigger('click');
 		});
 	}
 
 	function translateAll()
 	{
-		if(bingTranslateComplete){
-			alert(Joomla.JText._('COM_LOCALISE_BINGTRANSLATING_NOW'));
-			return false;
-		}
-
-		bingTranslateComplete = true;
-		var targets = $$('i.translate');
-		AzureTranslator(targets[0], targets, 0, '<?php echo JSession::getFormToken();?>');
+		jQuery('i.js-localise-btn-translate').each(function(){
+			jQuery(this).trigger('click');
+		})
 	}
 
 	Joomla.submitbutton = function(task)

--- a/component/admin/views/translator/view.json.php
+++ b/component/admin/views/translator/view.json.php
@@ -33,13 +33,19 @@ class LocaliseViewTranslator extends JViewLegacy
 
 		$id = JFactory::getApplication()->input->getInt('id');
 
-		if (!JSession::checkToken()
+		if (!JSession::checkToken('get')
 			|| !JFactory::getUser()->authorise('core.edit', 'com_localise.edit.' . $id))
 		{
 			return false;
 		}
 
-		$text = $this->get('text');
+		$model = $this->getModel();
+		$text = $model->getText();
+
+		if (false === $text)
+		{
+			$results['text'] = $model->getError();
+		}
 
 		if (!empty($text))
 		{

--- a/localise.xml
+++ b/localise.xml
@@ -49,6 +49,7 @@
 			<folder>controllers</folder>
 			<folder>help</folder>
 			<folder>helpers</folder>
+			<folder>lang</folder>
 			<folder>language</folder>
 			<folder>layouts</folder>
 			<folder>models</folder>

--- a/media/com_localise/js/field-key.js
+++ b/media/com_localise/js/field-key.js
@@ -1,0 +1,42 @@
+(function($){
+	$(document).ready(function () {
+
+		$('.js-localise-btn-import').click(function(){
+			var targetSelector = $(this).attr('data-import'),
+				referenceSelector = targetSelector + '-reference',
+				$targetField   = $('#' + targetSelector),
+				$referenceField   = $('#' + referenceSelector);
+
+			$targetField.val($referenceField.val()).trigger('focusout');
+		});
+
+		$('.js-localise-btn-translate').click(function(){
+			var token = $(this).attr('data-token');
+
+			AzureTranslator(this, [], 0, token);
+		});
+
+		$('.js-localise-field-translation').on('focusout', function(){
+			var id = $(this).attr('id'),
+				referenceValue = $('#' + id + '-reference').val(),
+				originalValue = $('#' + id + '-original').val(),
+				value = $(this).val(),
+				currentStatus = $(this).attr('data-status'),
+				newStatus = currentStatus;
+
+			$(this).removeClass(currentStatus);
+
+			if (currentStatus != 'extra') {
+				if (value == '') {
+					newStatus = 'untranslated';
+				} else if (value === referenceValue) {
+					newStatus = 'unchanged';
+				} else {
+					newStatus = 'translated';
+				}
+			}
+
+			$(this).addClass(newStatus).attr('data-status', newStatus);
+		});
+	});
+})(jQuery);

--- a/media/com_localise/js/parseini.js
+++ b/media/com_localise/js/parseini.js
@@ -62,7 +62,7 @@ CodeMirror.defineMode("parseini", function() {
 				}
 				else
 				{
-					checkString = string.replace(/"_QQ_"/g, '"');
+					checkString = string.replace(/"_QQ_"/g, '');
 					count = checkString.match(/"/g).length;
 				}
 

--- a/media/com_localise/js/parseini.js
+++ b/media/com_localise/js/parseini.js
@@ -52,18 +52,34 @@ CodeMirror.defineMode("parseini", function() {
 			}
 			else if (ch === '"' && state.position === "string")
 			{
-				state.position = "string";
-				stream.skipTo('"'); stream.eat('"');
-				return 'string';
-			}
-			else if (ch === '_' && state.position === "string")
-			{
-				if(stream.match('QQ_'))
+				var count,
+					string = stream.string.substring(stream.start, stream.string.length),
+					checkString = string.replace(/"_QQ_"/g, 'QQQQQ');
+
+				if (checkString.charAt(0) !== '"' || checkString.charAt(checkString.length - 1) !== '"')
 				{
-					state.position = "string";
-					return 'constant';
+					count = 1;
 				}
-				return "error";
+				else
+				{
+					checkString = string.replace(/"_QQ_"/g, '"');
+					count = checkString.match(/"/g).length;
+				}
+
+				// Move until the last string quotes
+				while(stream.skipTo('"'))
+				{
+					stream.eat('"');
+				}
+
+				if (count % 2)
+				{
+					return 'error';
+				}
+
+				state.position = "string";
+
+				return 'string';
 			}
 			else
 			{


### PR DESCRIPTION
Fixes https://github.com/joomla-projects/com_localise/issues/257

The main idea is that we stop using helpers and hardcoded checks and we use a common base class. I just called it `LocaliseLangFile`. Ideally we should create a `lib_localise` library to store all this things.

This only cleans localise helper and the models involved in file checking but I'm sure we can use it in more places to get things simpler.
### LocaliseLangFile basics

To check a file for errors:

``` php
// $path contains the path to the language file
$langFile = LocaliseLangFile::getInstance($path);

if (!$langFile->check())
{
    // Errors contains detailed errors
    $errors = $langFile->getLinesErrors();
}
```

To get the list of language strings:

``` php
$langFile = LocaliseLangFile::getInstance($path);

$strings = $langFile->getStrings();

// Errors encountered
if (false === $strings)
{
    // All the errors
    $errors = $langFile->getErrors();

    // Last error
    $error = $langFile->getLastError();
}

// Process $strings here
```

While testing errors I found that core has some inconsistency between file error checking && files not loaded in languages. This system is better than core checks and works the same for codemirror and on PHP checks. I tried to maximize the error detection so we can be sure that if a string isn't loaded it will be marked as wrong. Additionally I added errors that core "passes" but produce crap strings.

In fact I think this should go to core so language file handling & checking is abstracted from the language itself and can be reused by third part devs. I'd be happy to contribute it directly to core or as a more complex thing with a common interface and support for different type of language files in https://github.com/joomla-framework/language. I don't know really where it should go.
