### PR TITLE
Choosing reference file priority

### DIFF
--- a/component/admin/config.xml
+++ b/component/admin/config.xml
@@ -72,6 +72,16 @@
 			label="COM_LOCALISE_LABEL_SUFFIXES"
 			description="COM_LOCALISE_LABEL_SUFFIXES_DESC" />
 		<field
+			name="priority"
+			type="radio"
+			class="btn-group btn-group-yesno"
+			default="0"
+			label="COM_LOCALISE_LABEL_PRIORITY"
+			description="COM_LOCALISE_LABEL_PRIORITY_DESC">
+			<option value="0">JNO</option>
+			<option value="1">JYES</option>
+		</field>
+		<field
 			name="clientID"
 			type="text"
 			class="ltr"

--- a/component/admin/helpers/localise.php
+++ b/component/admin/helpers/localise.php
@@ -515,11 +515,14 @@ abstract class LocaliseHelper
 	 */
 	public static function findTranslationPath($client, $tag, $filename)
 	{
-		$path = static::getTranslationPath($client, $tag, $filename, 'local');
+		$params = JComponentHelper::getParams('com_localise');
+		$priority = $params->get('priority', '0') == '0' ? 'global' : 'local';
+		$path = static::getTranslationPath($client, $tag, $filename, $priority);
 
 		if (!is_file($path))
 		{
-			$path = static::getTranslationPath($client, $tag, $filename, 'global');
+			$priority = $params->get('priority', '0') == '0' ? 'local' : 'global';
+			$path = static::getTranslationPath($client, $tag, $filename, $priority);
 		}
 
 		return $path;

--- a/component/admin/language/en-GB/en-GB.com_localise.ini
+++ b/component/admin/language/en-GB/en-GB.com_localise.ini
@@ -59,6 +59,8 @@ COM_LOCALISE_LABEL_COPYRIGHT="Copyright"
 COM_LOCALISE_LABEL_COPYRIGHT_DESC="Standard copyright information"
 COM_LOCALISE_LABEL_LICENSE="License"
 COM_LOCALISE_LABEL_LICENSE_DESC="GNU/GPL"
+COM_LOCALISE_LABEL_PRIORITY="Priority to extension folder"
+COM_LOCALISE_LABEL_PRIORITY_DESC="If the file exists, setting this to Yes will present as reference the files from the extension folder. Default is No, i.e. use the files from core folder." 
 COM_LOCALISE_LABEL_SUFFIXES="Suffixes of language's files"
 COM_LOCALISE_LABEL_SUFFIXES_DESC="Enter the suffixes of your language files. Separate suffixes with a comma. Example: if the name of your language files are 'en-GB.com_admin.sys.ini' and 'en-GB.com_admin.menu.ini', suffixes should be '.sys, .menu'"
 


### PR DESCRIPTION
To test before patch:
In core, change manually some words in the value of a string for an extension which has his language files at the same time in the extension folder and in the core folder.
A simple example is the languagecode system plugin.
Change for example in the file in the core folder (en-GB.plg_system_languagecode.ini) the string
`PLG_SYSTEM_LANGUAGECODE_FIELDSET_LABEL="Language codes"`
to
`PLG_SYSTEM_LANGUAGECODE_FIELDSET_LABEL="MY language codes"`

then load com_localise with en-GB as reference, another language as target, and edit the file.
You will still see
![screen shot 2015-02-07 at 18 47 24](https://cloud.githubusercontent.com/assets/869724/6093067/d6abffbc-aef9-11e4-84bf-f0462d9f2ce9.png)

This is because com_localise gives priority to the "local" file (i.e. the file in the extension/language/en-GB/folder instead of the file in the core folder ("global").

Now patch and test:
If you do not touch at the Options, the priority is now to the "global" folder.
Editing the file will display the correct value above which you changed in the core folder.

Then play with the new parameter in the Options (Default is No):
"Priority to extension folder"

You will get the correct value depending on these settings.
