### PR TITLE
Listing available languages in the language filters depending on the client settings

### DIFF
--- a/component/admin/models/fields/language.php
+++ b/component/admin/models/fields/language.php
@@ -37,6 +37,8 @@ class JFormFieldLanguage extends JFormFieldList
 	 */
 	protected function getOptions()
 	{
+		$app  = JFactory::getApplication();
+		$state = $app->getUserState('com_localise.select');
 		$attributes = '';
 
 		if ($v = (string) $this->element['onchange'])
@@ -58,7 +60,24 @@ class JFormFieldLanguage extends JFormFieldList
 			$install = array();
 		}
 
-		$languages  = array_merge($admin, $site, $install);
+		// Listing languages in the language filter depending on the client filter
+		if ($state['client'] == 'installation')
+		{
+			$languages = $install;
+		}
+		elseif ($state['client'] == 'administrator')
+		{
+			$languages = $admin;
+		}
+		elseif ($state['client'] == 'site')
+		{
+			$languages = $site;
+		}
+		else
+		{
+			$languages  = array_merge($admin, $site, $install);
+		}
+
 		$attributes .= ' class="' . (string) $this->element['class'] . ($this->value == $reference ? ' iconlist-16-reference"' : '"');
 
 		foreach ($languages as $i => $language)


### PR DESCRIPTION
Before this PR, all available languages, for whatever client they do really exist (i.e. where there is an xx-XX.xml), will be displayed as a choice in the language filters in Languages Manager and Translations Manager,
This PR will only display the available language depending on the client.
Before patch (example client is site but all installation-only languages display:

![screen shot 2015-02-09 at 12 20 35](https://cloud.githubusercontent.com/assets/869724/6105316/1e959c7c-b056-11e4-87c7-5200bb051acc.png)

After patch, we will get:

![screen shot 2015-02-09 at 12 18 00](https://cloud.githubusercontent.com/assets/869724/6105291/dcf8b2b8-b055-11e4-9065-5018af1ee692.png)
