### PR TITLE
Changing pack name

### DIFF
--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -521,9 +521,19 @@ class LocaliseModelPackage extends JModelAdmin
 		else
 		{
 			$table = $this->getTable();
+
+			if (!$table->delete((int) $originalId))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
 			$table->store();
+
 			$id = LocaliseHelper::getFileId($path);
 			$this->setState('package.id', $id);
+			$app->setUserState('com_localise.edit.package.id', $id);
 		}
 
 		if (isset($data['rules']))
@@ -555,15 +565,6 @@ class LocaliseModelPackage extends JModelAdmin
 			{
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
-
-			if (!$table->delete((int) $originalId))
-			{
-				$this->setError($table->getError());
-
-				return false;
-			}
-
-			$app->setUserState('com_localise.edit.package.id', $id);
 
 			// Redirect to the new $id as name has changed
 			$app->redirect(JRoute::_('index.php?option=com_localise&view=package&layout=edit&id=' . $this->getState('package.id'), false));

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -558,7 +558,7 @@ class LocaliseModelPackage extends JModelAdmin
 			return false;
 		}
 
-		// Delete the older file
+		// Delete the older file and redirect
 		if ($path !== $oldpath && file_exists($oldpath))
 		{
 			if (!JFile::delete($oldpath))
@@ -566,8 +566,17 @@ class LocaliseModelPackage extends JModelAdmin
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
 
-			// Redirect to the new $id as name has changed
-			$app->redirect(JRoute::_('index.php?option=com_localise&view=package&layout=edit&id=' . $this->getState('package.id'), false));
+			$task = JFactory::getApplication()->input->get('task');
+
+			if ($task == 'save')
+			{
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+			}
+			else
+			{
+				// Redirect to the new $id as name has changed
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=package&layout=edit&id=' . $this->getState('package.id'), false));
+			}
 		}
 
 		$this->cleanCache();

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -509,12 +509,22 @@ class LocaliseModelPackage extends JModelAdmin
 			return false;
 		}
 		*/
-		$id = LocaliseHelper::getFileId($path);
-		$this->setState('package.id', $id);
+		if ($path == $oldpath)
+		{
+			$id = LocaliseHelper::getFileId($path);
+			$this->setState('package.id', $id);
 
-		// Bind the rules.
-		$table = $this->getTable();
-		$table->load($id);
+			// Bind the rules.
+			$table = $this->getTable();
+			$table->load($id);
+		}
+		else
+		{
+			$table = $this->getTable();
+			$table->store();
+			$id = LocaliseHelper::getFileId($path);
+			$this->setState('package.id', $id);
+		}
 
 		if (isset($data['rules']))
 		{

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -496,12 +496,22 @@ class LocaliseModelPackageFile extends JModelAdmin
 		}
 
 		*/
-		$id = LocaliseHelper::getFileId($path);
-		$this->setState('packagefile.id', $id);
+		if ($path == $oldpath)
+		{
+			$id = LocaliseHelper::getFileId($path);
+			$this->setState('packagefile.id', $id);
 
-		// Bind the rules.
-		$table = $this->getTable();
-		$table->load($id);
+			// Bind the rules.
+			$table = $this->getTable();
+			$table->load($id);
+		}
+		else
+		{
+			$table = $this->getTable();
+			$table->store();
+			$id = LocaliseHelper::getFileId($path);
+			$this->setState('packagefile.id', $id);
+		}
 
 		if (isset($data['rules']))
 		{
@@ -543,7 +553,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 			$app->setUserState('com_localise.edit.packagefile.id', $id);
 
 			// Redirect to the new $id as name has changed
-			$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('package.id'), false));
+			$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('packagefile.id'), false));
 		}
 
 		$this->cleanCache();

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -545,7 +545,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 			return false;
 		}
 
-		// Delete the older file
+		// Delete the older file and redirect
 		if ($path !== $oldpath && file_exists($oldpath))
 		{
 			if (!JFile::delete($oldpath))
@@ -553,8 +553,17 @@ class LocaliseModelPackageFile extends JModelAdmin
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
 
-			// Redirect to the new $id as name has changed
-			$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('packagefile.id'), false));
+			$task = JFactory::getApplication()->input->get('task');
+
+			if ($task == 'save')
+			{
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packages', false));
+			}
+			else
+			{
+				// Redirect to the new $id as name has changed
+				$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('packagefile.id'), false));
+			}
 		}
 
 		$this->cleanCache();

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -508,9 +508,19 @@ class LocaliseModelPackageFile extends JModelAdmin
 		else
 		{
 			$table = $this->getTable();
+
+			if (!$table->delete((int) $originalId))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+
 			$table->store();
+
 			$id = LocaliseHelper::getFileId($path);
-			$this->setState('packagefile.id', $id);
+			$this->setState('package.id', $id);
+			$app->setUserState('com_localise.edit.packagefile.id', $id);
 		}
 
 		if (isset($data['rules']))
@@ -535,22 +545,13 @@ class LocaliseModelPackageFile extends JModelAdmin
 			return false;
 		}
 
-	// Delete the older file
+		// Delete the older file
 		if ($path !== $oldpath && file_exists($oldpath))
 		{
 			if (!JFile::delete($oldpath))
 			{
 				$app->enqueueMessage(JText::_('COM_LOCALISE_ERROR_OLDFILE_REMOVE'), 'notice');
 			}
-
-			if (!$table->delete((int) $originalId))
-			{
-				$this->setError($table->getError());
-
-				return false;
-			}
-
-			$app->setUserState('com_localise.edit.packagefile.id', $id);
 
 			// Redirect to the new $id as name has changed
 			$app->redirect(JRoute::_('index.php?option=com_localise&view=packagefile&layout=edit&id=' . $this->getState('packagefile.id'), false));

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -519,7 +519,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 			$table->store();
 
 			$id = LocaliseHelper::getFileId($path);
-			$this->setState('package.id', $id);
+			$this->setState('packagefile.id', $id);
 			$app->setUserState('com_localise.edit.packagefile.id', $id);
 		}
 


### PR DESCRIPTION
The issue is the following:

In Localisation Manager: Packages

![screen shot 2015-02-16 at 11 38 18](https://cloud.githubusercontent.com/assets/869724/6210460/6674f41e-b5d0-11e4-9ae5-2263344199fe.png)
1. Duplicate a master core pack.
   for example: Master core 340 pack (master_core340) 
   to get: Master core 340 pack (master_core340_2015-02-16-10-10-42) 
2. Edit the new package and change name and title. Enter the joomla version and language version. 
3. Save or Save and Close.

Result: one gets a 500 and it is necessary to logout/login again to be able to edit the new package and do any usual task.

This patch should solve the issue. Before testing, make sure you have logged out/in after the the first test.

Remains one aspect: Save and Close does not display the packages view, but the edited package again and the Save & Close button has to be clicked a second time to get to the packages view.
Help welcome to solve that one.
