### PR TITLE
Throw a warning when max_input_vars value is too low.

### DIFF
--- a/component/admin/language/en-GB/en-GB.com_localise.ini
+++ b/component/admin/language/en-GB/en-GB.com_localise.ini
@@ -211,6 +211,8 @@ COM_LOCALISE_TOOLTIP_TRANSLATION_AZURE="<b>Windows Azure</b><br/>Click to find a
 [Translations]
 
 COM_LOCALISE_ERROR_CHOOSE_LANG_CLIENT="Please choose a location AND a language in the filters."
+COM_LOCALISE_ERROR_MAX_INPUT_VAR="The value of the PHP directive <strong>max_input_vars</strong> is lower than the required one to edit the file: %1$s.%2$s.ini<br /><br />You have to modify your php.ini file to change this limit (which is set to 1000 per default). <br />Use for example <strong>max_input_vars = 10000</strong><br />If the environment is running on <strong>suhosin</strong>, and ONLY in this case, add/change: <br />suhosin.post.max_vars = 10000<br />suhosin.request.max_vars = 10000<br /> and restart Apache."
+COM_LOCALISE_ERROR_MAX_INPUT_VAR_PROTECTION="(Strings protection)"
 COM_LOCALISE_HEADER_TRANSLATIONS="Translations"
 COM_LOCALISE_HEADING_TRANSLATIONS_AUTHOR="Author"
 COM_LOCALISE_HEADING_TRANSLATIONS_INFORMATION="Information"

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -225,6 +225,10 @@ class LocaliseModelTranslation extends JModelAdmin
 										'unchanged'           => 0,
 										'extra'               => 0,
 										'total'               => 0,
+										'linespath'           => 0,
+										'linesrefpath'        => 0,
+										'linesdevpath'        => 0,
+										'linescustompath'     => 0,
 										'complete'            => false,
 										'source'              => '',
 										'error'               => array()
@@ -438,6 +442,13 @@ class LocaliseModelTranslation extends JModelAdmin
 						if (!preg_match('/^(|(\[[^\]]*\])|([A-Z][A-Z0-9_\*\-\.]*\s*=(\s*(("[^"]*")|(_QQ_)))+))\s*(;.*)?$/', $line))
 						{
 							$this->item->error[] = $lineNumber;
+						}
+					}
+					if ($tag != $reftag)
+					{
+						if (JFile::exists($custompath))
+						{
+							$this->item->linescustompath = count(file($custompath));
 						}
 					}
 
@@ -657,6 +668,32 @@ class LocaliseModelTranslation extends JModelAdmin
 				if ($caching)
 				{
 					$cache->store($this->item, $keycache);
+				}
+
+				// Count the number of lines in the ini file to check max_input_vars
+				if ($tag != $reftag)
+				{
+					if (JFile::exists($path))
+					{
+						$this->item->linespath = count(file($path));
+					}
+
+					if (JFile::exists($refpath))
+					{
+						$this->item->linesrefpath = count(file($refpath));
+					}
+
+					if (JFile::exists($develop_file_path))
+					{
+						$this->item->linesdevpath = count(file($develop_file_path));
+					}
+				}
+				else
+				{
+					if (JFile::exists($path))
+					{
+						$this->item->linespath = count(file($path));
+					}
 				}
 			}
 		}

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -444,6 +444,7 @@ class LocaliseModelTranslation extends JModelAdmin
 							$this->item->error[] = $lineNumber;
 						}
 					}
+
 					if ($tag != $reftag)
 					{
 						if (JFile::exists($custompath))

--- a/component/admin/views/translations/tmpl/default_body.php
+++ b/component/admin/views/translations/tmpl/default_body.php
@@ -16,8 +16,15 @@ $packages  = LocaliseHelper::getPackages();
 $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $lang      = JFactory::getLanguage();
+$max_vars = ini_get('max_input_vars');
 ?>
 <?php foreach ($this->items as $i => $item) : ?>
+	<?php $limit = 0; ?>
+	<?php if ($max_vars > 0) : ?>
+		<?php if ($item->linespath > $max_vars || $item->linesrefpath > $max_vars || $item->linesdevpath > $max_vars || $item->linescustompath > $max_vars) : ?>
+			<?php $limit = 1; ?>
+		<?php endif; ?>
+	<?php endif; ?>
 	<?php $canEdit = $user->authorise('localise.edit', 'com_localise' . (isset($item->id) ? ('.' . $item->id) : '')); ?>
 	<?php $istranslation = $item->istranslation; ?>
 	<?php if (!empty($item->developdata)) :
@@ -73,9 +80,14 @@ $lang      = JFactory::getLanguage();
 				<input type="checkbox" id="cb<?php echo $i; ?>" class="hidden" name="cid[]" value="<?php echo $item->id; ?>">
 			<?php endif; ?>
 			<?php if ($item->writable && !$item->error && $canEdit) : ?>
-				<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage)).($item->filename=='override' ? '&layout=raw' :'')); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">
-				<?php echo $item->name; ?>.ini
-				</a>
+				<?php if ($limit == 0) : ?>
+					<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_localise&task=translation.edit&client='.$item->client.'&tag='.$item->tag.'&filename='.$item->filename.'&storage='.$item->storage.'&id='.LocaliseHelper::getFileId(LocaliseHelper::getTranslationPath($item->client,$item->tag, $item->filename, $item->storage))); ?>" title="<?php echo JText::_('COM_LOCALISE_TOOLTIP_TRANSLATIONS_' . ($item->state=='unexisting' ? 'NEW' : 'EDIT')); ?>">
+					<?php echo $item->name; ?>.ini
+					</a>
+				<?php else : ?>
+					<?php echo "<font color=\"red\">" . $item->name . ".ini " . JText::_('COM_LOCALISE_ERROR_MAX_INPUT_VAR_PROTECTION') . "</font>"; ?>
+					<?php $app->enqueueMessage(JText::sprintf('COM_LOCALISE_ERROR_MAX_INPUT_VAR', $item->tag, $item->name), 'warning'); ?>
+				<?php endif; ?>
 			<?php elseif (!$canEdit) : ?>
 				<?php echo JHtml::_('jgrid.action', $i, '', array('tip'=>true, 'inactive_title'=>JText::sprintf('COM_LOCALISE_TOOLTIP_TRANSLATIONS_NOTEDITABLE', substr($item->path, strlen(JPATH_ROOT))), 'inactive_class'=>'16-error', 'enabled' => false, 'translate'=>false)); ?>
 				<?php echo $item->name; ?>.ini

--- a/component/admin/views/translations/tmpl/default_references.php
+++ b/component/admin/views/translations/tmpl/default_references.php
@@ -50,7 +50,7 @@ $has_installation  = LocaliseHelper::hasInstallation();
 					$client,
 					$last_source[$client],
 					$installed_version),
-				'warning');
+				'notice');
 		}
 	}
 
@@ -96,14 +96,14 @@ $has_installation  = LocaliseHelper::hasInstallation();
 				$equal_versions = 0;
 			}
 		}
-		
+
 		if (($version['administrator'] == '0' || $version['administrator'] == $installed_version)
 		&& ($version['site'] == '0' || $version['site'] == $installed_version))
 		{
 			$matches = 1;
 
 			if ($has_installation && $matches == 1)
-			{				
+			{
 				if ($version['installation'] == '0' || $version['installation'] == $installed_version)
 				{
 					$equal_versions = 2;
@@ -151,7 +151,7 @@ $has_installation  = LocaliseHelper::hasInstallation();
 				$report .= '<br />';
 			}
 		}
-		
+
 		$report .= '</i>';
 		// End notes
 


### PR DESCRIPTION
This PR, based partly on code from @Valc in https://github.com/joomla-projects/com_localise/pull/276
implements a Warning when the php.ini directive `max_input_vars` is lower than required to edit an ini file. It also prevents editing the file except under Source.

One should get:

![screen shot 2016-03-17 at 16 37 42](https://cloud.githubusercontent.com/assets/869724/13851470/a4afd3dc-ec5e-11e5-8f2b-9f9e692b266d.png)

The default on most systems is 1000 if the directive is not set at all.
To test, add 50 lines to admin en-GB.ini.
Modify the directive and test again.

The reason we can't use `$item->total` is that lines with comments are also counted as variables.
