### PR TITLE
Improve travis tests: test other php versions (5.6, 7 and hhvm); run code style tests only on one php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
+    - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 before_script:
   # Make sure all dev dependencies are installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 
 language: php
 
-env:
-  global:
-    - RUN_PHPCS="no"
-
 matrix:
   include:
     - php: 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ sudo: false
 
 language: php
 
+env:
+  global:
+    - RUN_PHPCS="no"
+
 matrix:
   include:
     - php: 5.3
     - php: 5.4
     - php: 5.5
     - php: 5.6
+      env: RUN_PHPCS="yes"
     - php: 7.0
     - php: hhvm
   allow_failures:
@@ -20,5 +25,5 @@ before_script:
 
 script:
   - php .travis/phppec.php component/
-  - php .travis/phpcs.php
+  - if [[ $RUN_PHPCS == "yes" ]]; then php .travis/phpcs.php; fi
   - php .travis/phpmd.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
+# Forces new Travis-CI Infrastructure
+sudo: false
+
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
+env:
+  global:
+    - RUN_PHPCS="no"
+
+matrix:
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
 
 before_script:
+  # Make sure all dev dependencies are installed
   - composer install
 
 script:


### PR DESCRIPTION
Check code difference

I'm not sure is anything else is needed.

the patchtester travis.yml is a little different reggarding CS
See https://github.com/joomla-extensions/patchtester/blob/master/.travis.yml
