### PR TITLE
Make sure EOL is Unix and not Windows (solves #297)

### DIFF
--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -1397,6 +1397,9 @@ class LocaliseModelTranslation extends JModelAdmin
 			$contents = $contents2 . $contents;
 		}
 
+		// Make sure EOL is Unix
+		$contents = str_replace(array("\r\n", "\n", "\r"), "\n", $contents);
+
 		$return = JFile::write($path, $contents);
 
 		// Try to make the template file unwriteable.


### PR DESCRIPTION
When saving a file using Raw mode (Source edit), the file end of lines are CRLF i.e. Windows, instead of LF i.e. Unix.

This comes from a flaw in CodeMirror.
This solves the issue for com_localise.
