### PR TITLE
J4 compat

### DIFF
--- a/component/admin/localise.php
+++ b/component/admin/localise.php
@@ -9,10 +9,19 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Exception\NotAllowed;
+
 // Access check.
 if (!JFactory::getUser()->authorise('core.manage', 'com_localise'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	if (version_compare(JVERSION, '4.0', 'ge'))
+	{
+		throw new NotAllowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
+	}
+	else
+	{
+		return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	}
 }
 
 // Include helper files

--- a/component/admin/models/fields/corelanguage.php
+++ b/component/admin/models/fields/corelanguage.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JFormHelper::loadFieldClass('list');
 
 /**
@@ -53,10 +55,10 @@ class JFormFieldCoreLanguage extends JFormFieldList
 
 		foreach ($languages as $i => $language)
 		{
-			$languages[$i] = JArrayHelper::toObject($language);
+			$languages[$i] = ArrayHelper::toObject($language);
 		}
 
-		JArrayHelper::sortObjects($languages, 'name');
+		ArrayHelper::sortObjects($languages, 'name');
 		$options = array();
 
 		foreach ($this->element->children() as $option)

--- a/component/admin/models/fields/corelanguage.php
+++ b/component/admin/models/fields/corelanguage.php
@@ -47,8 +47,17 @@ class JFormFieldCoreLanguage extends JFormFieldList
 
 		$params    = JComponentHelper::getParams('com_localise');
 		$reference = $params->get('reference', 'en-GB');
-		$admin     = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
-		$site      = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+
+		if (version_compare(JVERSION, '4.0', 'ge'))
+		{
+			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);
+		}
+		else
+		{
+			$admin = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+		}
 
 		$languages  = array_merge($admin, $site);
 		$attributes .= ' class="' . (string) $this->element['class'] . ($this->value == $reference ? ' iconlist-16-reference"' : '"');

--- a/component/admin/models/fields/corelanguage.php
+++ b/component/admin/models/fields/corelanguage.php
@@ -48,7 +48,7 @@ class JFormFieldCoreLanguage extends JFormFieldList
 		$params    = JComponentHelper::getParams('com_localise');
 		$reference = $params->get('reference', 'en-GB');
 
-		if (version_compare(JVERSION, '4.0', 'ge'))
+		if (version_compare(JVERSION, '3.7', 'ge'))
 		{
 			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
 			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);

--- a/component/admin/models/fields/extensiontranslations.php
+++ b/component/admin/models/fields/extensiontranslations.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.html.html');
 jimport('joomla.filesystem.folder');
 JFormHelper::loadFieldClass('groupedlist');
@@ -147,7 +149,7 @@ class JFormFieldExtensionTranslations extends JFormFieldGroupedList
 			}
 			else
 			{
-				JArrayHelper::sortObjects($groups[$client], 'text');
+				ArrayHelper::sortObjects($groups[$client], 'text');
 			}
 		}
 

--- a/component/admin/models/fields/language.php
+++ b/component/admin/models/fields/language.php
@@ -50,12 +50,28 @@ class JFormFieldLanguage extends JFormFieldList
 
 		$params    = JComponentHelper::getParams('com_localise');
 		$reference = $params->get('reference', 'en-GB');
-		$admin     = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
-		$site      = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+
+		if (version_compare(JVERSION, '4.0', 'ge'))
+		{
+			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);
+		}
+		else
+		{
+			$admin = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+		}
 
 		if (JFolder::exists(LOCALISEPATH_INSTALLATION))
 		{
-			$install = JLanguage::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			if (version_compare(JVERSION, '4.0', 'ge'))
+			{
+				$install = JLanguageHelper::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			}
+			else
+			{
+				$install = JLanguage::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			}
 		}
 		else
 		{

--- a/component/admin/models/fields/language.php
+++ b/component/admin/models/fields/language.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.filesystem.folder');
 JFormHelper::loadFieldClass('list');
 
@@ -82,10 +84,10 @@ class JFormFieldLanguage extends JFormFieldList
 
 		foreach ($languages as $i => $language)
 		{
-			$languages[$i] = JArrayHelper::toObject($language);
+			$languages[$i] = ArrayHelper::toObject($language);
 		}
 
-		JArrayHelper::sortObjects($languages, 'name');
+		ArrayHelper::sortObjects($languages, 'name');
 		$options = array();
 
 		foreach ($this->element->children() as $option)

--- a/component/admin/models/fields/language.php
+++ b/component/admin/models/fields/language.php
@@ -51,7 +51,7 @@ class JFormFieldLanguage extends JFormFieldList
 		$params    = JComponentHelper::getParams('com_localise');
 		$reference = $params->get('reference', 'en-GB');
 
-		if (version_compare(JVERSION, '4.0', 'ge'))
+		if (version_compare(JVERSION, '3.7', 'ge'))
 		{
 			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
 			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);
@@ -64,7 +64,7 @@ class JFormFieldLanguage extends JFormFieldList
 
 		if (JFolder::exists(LOCALISEPATH_INSTALLATION))
 		{
-			if (version_compare(JVERSION, '4.0', 'ge'))
+			if (version_compare(JVERSION, '3.7', 'ge'))
 			{
 				$install = JLanguageHelper::getKnownLanguages(LOCALISEPATH_INSTALLATION);
 			}

--- a/component/admin/models/fields/origin.php
+++ b/component/admin/models/fields/origin.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.form.formfield');
 
 /**
@@ -90,7 +92,7 @@ class JFormFieldOrigin extends JFormField
 		}
 		*/
 
-		$packages_options = JArrayHelper::sortObjects($packages_options, 'text');
+		$packages_options = ArrayHelper::sortObjects($packages_options, 'text');
 		$thirdparty       = JHtml::_('select.option', '_thirdparty', JText::sprintf('COM_LOCALISE_OPTION_TRANSLATIONS_ORIGIN_THIRDPARTY'),
 							array('option.attr' => 'attributes', 'attr' => 'class="iconlist-16-thirdparty"')
 							);

--- a/component/admin/models/fields/referencelanguage.php
+++ b/component/admin/models/fields/referencelanguage.php
@@ -40,12 +40,28 @@ class JFormFieldReferenceLanguage extends JFormFieldList
 	 */
 	protected function getOptions()
 	{
-		$admin = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
-		$site  = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+		if (version_compare(JVERSION, '4.0', 'ge'))
+		{
+			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);
+		}
+		else
+		{
+			$admin = JLanguage::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
+			$site  = JLanguage::getKnownLanguages(LOCALISEPATH_SITE);
+		}
 
 		if (JFolder::exists(LOCALISEPATH_INSTALLATION))
 		{
-			$installation = JLanguage::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			if (version_compare(JVERSION, '4.0', 'ge'))
+			{
+				$installation = JLanguageHelper::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			}
+			else
+			{
+				$installation = JLanguage::getKnownLanguages(LOCALISEPATH_INSTALLATION);
+			}
+
 			$languages    = array_intersect_key($admin, $site, $installation);
 		}
 		else

--- a/component/admin/models/fields/referencelanguage.php
+++ b/component/admin/models/fields/referencelanguage.php
@@ -40,7 +40,7 @@ class JFormFieldReferenceLanguage extends JFormFieldList
 	 */
 	protected function getOptions()
 	{
-		if (version_compare(JVERSION, '4.0', 'ge'))
+		if (version_compare(JVERSION, '3.7', 'ge'))
 		{
 			$admin = JLanguageHelper::getKnownLanguages(LOCALISEPATH_ADMINISTRATOR);
 			$site  = JLanguageHelper::getKnownLanguages(LOCALISEPATH_SITE);
@@ -53,7 +53,7 @@ class JFormFieldReferenceLanguage extends JFormFieldList
 
 		if (JFolder::exists(LOCALISEPATH_INSTALLATION))
 		{
-			if (version_compare(JVERSION, '4.0', 'ge'))
+			if (version_compare(JVERSION, '3.7', 'ge'))
 			{
 				$installation = JLanguageHelper::getKnownLanguages(LOCALISEPATH_INSTALLATION);
 			}

--- a/component/admin/models/fields/referencelanguage.php
+++ b/component/admin/models/fields/referencelanguage.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JFormHelper::loadFieldClass('list');
 jimport('joomla.filesystem.folder');
 include_once JPATH_ADMINISTRATOR . '/components/com_localise/helpers/defines.php';
@@ -53,10 +55,10 @@ class JFormFieldReferenceLanguage extends JFormFieldList
 
 		foreach ($languages as $i => $language)
 		{
-			$languages[$i] = JArrayHelper::toObject($language);
+			$languages[$i] = ArrayHelper::toObject($language);
 		}
 
-		JArrayHelper::sortObjects($languages, 'name');
+		ArrayHelper::sortObjects($languages, 'name');
 
 		$options = parent::getOptions();
 

--- a/component/admin/models/fields/translations.php
+++ b/component/admin/models/fields/translations.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.html.html');
 jimport('joomla.filesystem.folder');
 JFormHelper::loadFieldClass('groupedlist');
@@ -132,7 +134,7 @@ class JFormFieldTranslations extends JFormFieldGroupedList
 
 		foreach ($groups as $client => $extensions)
 		{
-			JArrayHelper::sortObjects($groups[$client], 'text');
+			ArrayHelper::sortObjects($groups[$client], 'text');
 		}
 
 		// Merge any additional options in the XML definition.

--- a/component/admin/models/language.php
+++ b/component/admin/models/language.php
@@ -142,7 +142,7 @@ class LocaliseModelLanguage extends JModelAdmin
 		}
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/languages.php
+++ b/component/admin/models/languages.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.filesystem.folder');
 
 /**
@@ -236,7 +238,7 @@ class LocaliseModelLanguages extends JModelList
 			$ordering = $this->getState('list.ordering')
 				? $this->getState('list.ordering')
 				: 'name';
-			JArrayHelper::sortObjects(
+			ArrayHelper::sortObjects(
 				$this->languages,
 				$ordering, $this->getState('list.direction') == 'desc' ? -1 : 1
 			);

--- a/component/admin/models/languages.php
+++ b/component/admin/models/languages.php
@@ -90,7 +90,7 @@ class LocaliseModelLanguages extends JModelList
 		$form = JForm::getInstance('com_localise.languages', 'languages', array('control' => 'filters','event'   => 'onPrepareForm'));
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -866,7 +866,17 @@ class LocaliseModelPackage extends JModelAdmin
 
 			$site_zip_path = JPATH_ROOT . '/tmp/' . uniqid('com_localise_') . '.zip';
 
-			if (!$packager = JArchive::getAdapter('zip'))
+			if (version_compare(JVERSION, '4.0', 'ge'))
+			{
+				$archiveClass = new \Joomla\Archive\Archive;
+				$packager = $archiveClass->getAdapter('zip');
+			}
+			else
+			{
+				$packager = JArchive::getAdapter('zip');
+			}
+
+			if (!$packager)
 			{
 				$this->setError(JText::_('COM_LOCALISE_ERROR_EXPORT_ADAPTER'));
 
@@ -1015,8 +1025,17 @@ class LocaliseModelPackage extends JModelAdmin
 			$admin_package_files[] = array('name' => 'index.html','data' => $language_data);
 
 			$admin_zip_path = JPATH_ROOT . '/tmp/' . uniqid('com_localise_') . '.zip';
+			if (version_compare(JVERSION, '4.0', 'ge'))
+			{
+				$archiveClass = new \Joomla\Archive\Archive;
+				$packager = $archiveClass->getAdapter('zip');
+			}
+			else
+			{
+				$packager = JArchive::getAdapter('zip');
+			}
 
-			if (!$packager = JArchive::getAdapter('zip'))
+			if (!$packager)
 			{
 				$this->setError(JText::_('COM_LOCALISE_ERROR_EXPORT_ADAPTER'));
 
@@ -1049,9 +1068,18 @@ class LocaliseModelPackage extends JModelAdmin
 		$main_package_files[] = array('name' => 'pkg_' . $data['language'] . '.xml', 'data' => $text);
 
 		$ziproot = JPATH_ROOT . '/tmp/' . uniqid('com_localise_main_') . '.zip';
+		if (version_compare(JVERSION, '4.0', 'ge'))
+		{
+			$archiveClass = new \Joomla\Archive\Archive;
+			$packager = $archiveClass->getAdapter('zip');
+		}
+		else
+		{
+			$packager = JArchive::getAdapter('zip');
+		}
 
 		// Run the packager
-		if (!$packager = JArchive::getAdapter('zip'))
+		if (!$packager)
 		{
 			$this->setError(JText::_('COM_LOCALISE_ERROR_EXPORT_ADAPTER'));
 

--- a/component/admin/models/package.php
+++ b/component/admin/models/package.php
@@ -85,7 +85,7 @@ class LocaliseModelPackage extends JModelAdmin
 		$form->setFieldAttribute('translations', 'package', $name, 'translations');
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 
@@ -133,7 +133,7 @@ class LocaliseModelPackage extends JModelAdmin
 		}
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -806,8 +806,18 @@ class LocaliseModelPackageFile extends JModelAdmin
 
 		$ziproot = JPATH_ROOT . '/tmp/' . uniqid('com_localise_main_') . '.zip';
 
+		if (version_compare(JVERSION, '4.0', 'ge'))
+		{
+			$archiveClass = new \Joomla\Archive\Archive;
+			$packager = $archiveClass->getAdapter('zip');
+		}
+		else
+		{
+			$packager = JArchive::getAdapter('zip');
+		}
+
 		// Run the packager
-		if (!$packager = JArchive::getAdapter('zip'))
+		if (!$packager)
 		{
 			$this->setError(JText::_('COM_LOCALISE_ERROR_EXPORT_ADAPTER'));
 

--- a/component/admin/models/packagefile.php
+++ b/component/admin/models/packagefile.php
@@ -85,7 +85,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 		$form->setFieldAttribute('translations', 'packagefile', $name, 'translations');
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 
@@ -133,7 +133,7 @@ class LocaliseModelPackageFile extends JModelAdmin
 		}
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/packages.php
+++ b/component/admin/models/packages.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.filesystem.folder');
 jimport('joomla.filesystem.file');
 
@@ -113,7 +115,7 @@ class LocaliseModelPackages extends JModelList
 			}
 
 			$ordering = $this->getState('list.ordering') ? $this->getState('list.ordering') : 'title';
-			JArrayHelper::sortObjects($this->packages, $ordering, $this->getState('list.direction') == 'desc' ? -1 : 1);
+			ArrayHelper::sortObjects($this->packages, $ordering, $this->getState('list.direction') == 'desc' ? -1 : 1);
 		}
 
 		return $this->packages;

--- a/component/admin/models/packages.php
+++ b/component/admin/models/packages.php
@@ -180,7 +180,7 @@ class LocaliseModelPackages extends JModelList
 		$form = JForm::getInstance('com_localise.packages', 'packages', array('control' => 'filters', 'event' => 'onPrepareForm'));
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -814,7 +814,14 @@ class LocaliseModelTranslation extends JModelAdmin
 
 		if (!array_key_exists($client, $languages))
 		{
-			$languages[$client] = JLanguage::getKnownLanguages(constant('LOCALISEPATH_' . strtoupper($client)));
+			if (version_compare(JVERSION, '4.0', 'ge'))
+			{
+				$languages[$client] = JLanguageHelper::getKnownLanguages(constant('LOCALISEPATH_' . strtoupper($client)));
+			}
+			else
+			{
+				$languages[$client] = JLanguage::getKnownLanguages(constant('LOCALISEPATH_' . strtoupper($client)));
+			}
 		}
 
 		if (is_object($item))

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -814,7 +814,7 @@ class LocaliseModelTranslation extends JModelAdmin
 
 		if (!array_key_exists($client, $languages))
 		{
-			if (version_compare(JVERSION, '4.0', 'ge'))
+			if (version_compare(JVERSION, '3.7', 'ge'))
 			{
 				$languages[$client] = JLanguageHelper::getKnownLanguages(constant('LOCALISEPATH_' . strtoupper($client)));
 			}

--- a/component/admin/models/translation.php
+++ b/component/admin/models/translation.php
@@ -771,7 +771,7 @@ class LocaliseModelTranslation extends JModelAdmin
 		}
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/models/translations.php
+++ b/component/admin/models/translations.php
@@ -148,7 +148,7 @@ class LocaliseModelTranslations extends JModelList
 		$form = JForm::getInstance('com_localise.translations', 'translations', array('control' => 'filters', 'event' => 'onPrepareForm'));
 
 		// Check for an error.
-		if (JError::isError($form))
+		if (version_compare(JVERSION, '4.0', 'le') && JError::isError($form))
 		{
 			$this->setError($form->getMessage());
 

--- a/component/admin/sql/install/mysql/install.sql
+++ b/component/admin/sql/install/mysql/install.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `#__localise` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `asset_id` int(11) NOT NULL,
+  `asset_id` int unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.',
   `path` varchar(255) NOT NULL,
   `checked_out` int(10) unsigned NOT NULL DEFAULT '0',
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',

--- a/component/admin/sql/updates/mysql/4.1.0.sql
+++ b/component/admin/sql/updates/mysql/4.1.0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__localise` MODIFY `asset_id` int unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.';

--- a/component/admin/views/language/tmpl/edit.php
+++ b/component/admin/views/language/tmpl/edit.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 $fieldSets = $this->form->getFieldsets();

--- a/component/admin/views/languages/tmpl/default.php
+++ b/component/admin/views/languages/tmpl/default.php
@@ -12,7 +12,15 @@ defined('_JEXEC') or die;
 JHtml::_('stylesheet', 'com_localise/localise.css', null, true);
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('jquery.framework');
-JHtml::_('behavior.framework', true);
+
+if (version_compare(JVERSION, '4.0', 'ge'))
+{
+	JHtml::_('behavior.core');
+}
+else
+{
+	JHtml::_('behavior.framework', true);
+}
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));

--- a/component/admin/views/package/tmpl/edit.php
+++ b/component/admin/views/package/tmpl/edit.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.formvalidator');
-JHtml::_('behavior.modal');
 JHtml::_('jquery.framework');
 
 $fieldSets = $this->form->getFieldsets();
@@ -138,33 +137,33 @@ JFactory::getDocument()->addScriptDeclaration("
 	</div>
 </form>
 
-<div id="fileModal" class="modal hide fade">
-	<div class="modal-header">
-		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-		<h3><?php echo JText::_('COM_LOCALISE_IMPORT_NEW_FILE_HEADER'); ?></h3>
-		<p><?php echo JText::_('COM_LOCALISE_IMPORT_NEW_FILE_DESC'); ?></p>
-	</div>
-	<div class="modal-body">
-		<div class="column">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_localise&task=package.uploadOtherFile&file=' . $this->file); ?>"
+<?php
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'fileModal',
+	array(
+		'title'       => JText::_('COM_LOCALISE_IMPORT_NEW_FILE_HEADER'),
+		'closeButton' => true,
+		'backdrop'    => 'static',
+		'keyboard'    => false,
+		'footer'      => '<button type="button" class="btn btn-primary" data' .
+            (version_compare(JVERSION, '4.0', 'ge') ? '-bs' : '') . '-dismiss="modal">' .
+            JText::_('COM_LOCALISE_MODAL_CLOSE') . '</button>' .
+            '<button type="button" class="hasTooltip btn btn-primary fileupload">' .
+			    JText::_('COM_LOCALISE_BUTTON_IMPORT') .
+			'</button>'
+	),
+	'<p>' . JText::_('COM_LOCALISE_IMPORT_NEW_FILE_DESC') . '</p>
+			<form method="post" action="' . JRoute::_('index.php?option=com_localise&task=package.uploadOtherFile&file=' . $this->file) . '"
 				class="well" enctype="multipart/form-data" name="filemodalForm" id="filemodalForm">
 				<fieldset>
-					<label><?php echo JText::_('COM_LOCALISE_TEXT_CLIENT'); ?></label>
+					<label>' . JText::_('COM_LOCALISE_TEXT_CLIENT') . '</label>
 					<select name="location" type="location" required >
-						<option value="admin"><?php echo JText::_('JADMINISTRATOR'); ?></option>
-						<option value="site"><?php echo JText::_('JSITE'); ?></option>
+						<option value="admin">' . JText::_('JADMINISTRATOR') . '</option>
+						<option value="site">' . JText::_('JSITE') . '</option>
 					</select>
 					<label></label>
 					<input type="file" name="files" required />
-					<a href="#" class="hasTooltip btn btn-primary fileupload">
-						<?php echo JText::_('COM_LOCALISE_BUTTON_IMPORT'); ?>
-					</a>
 				</fieldset>
-			</form>
-		</div>
-	</div>
-	<div class="modal-footer">
-		<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_LOCALISE_MODAL_CLOSE'); ?></a>
-	</div>
-</div>
-
+			</form>'
+);

--- a/component/admin/views/package/tmpl/edit.php
+++ b/component/admin/views/package/tmpl/edit.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.modal');
 JHtml::_('jquery.framework');
 

--- a/component/admin/views/packagefile/tmpl/edit.php
+++ b/component/admin/views/packagefile/tmpl/edit.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 
 $fieldSets = $this->form->getFieldsets();
 $ftpSets   = $this->formftp->getFieldsets();

--- a/component/admin/views/packages/tmpl/default.php
+++ b/component/admin/views/packages/tmpl/default.php
@@ -9,8 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.modal');
-JHTML::_('stylesheet', 'com_localise/localise.css', null, true);
+JHtml::_('stylesheet', 'com_localise/localise.css', null, true);
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('jquery.framework');
 JHtml::_('bootstrap.tooltip');
@@ -83,25 +82,26 @@ JFactory::getDocument()->addScriptDeclaration("
 	<!-- End Content -->
 </form>
 
-<div id="fileModal" class="modal hide fade">
-	<div class="modal-header">
-		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-		<h3><?php echo JText::_('COM_LOCALISE_IMPORT_NEW_PACKAGE_HEADER'); ?></h3>
-	</div>
-	<div class="modal-body">
-		<div class="column">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_localise&task=package.uploadFile&file=' . $this->file); ?>"
-				class="well" enctype="multipart/form-data" name="filemodalForm" id="filemodalForm">
-				<fieldset>
-					<input type="file" name="files" required />
-					<a href="#" class="hasTooltip btn btn-primary fileupload">
-						<?php echo JText::_('COM_LOCALISE_BUTTON_IMPORT'); ?>
-					</a>
-				</fieldset>
-			</form>
-		</div>
-	</div>
-	<div class="modal-footer">
-		<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_LOCALISE_MODAL_CLOSE'); ?></a>
-	</div>
-</div>
+<?php
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'fileModal',
+	array(
+		'title'       => JText::_('COM_LOCALISE_IMPORT_NEW_PACKAGE_HEADER'),
+		'closeButton' => true,
+		'backdrop'    => 'static',
+		'keyboard'    => false,
+		'footer'      => '<button type="button" class="btn btn-primary" data' .
+            (version_compare(JVERSION, '4.0', 'ge') ? '-bs' : '') . '-dismiss="modal">' .
+            JText::_('COM_LOCALISE_MODAL_CLOSE') . '</button>' .
+            '<button type="button" class="hasTooltip btn btn-primary fileupload">' .
+			    JText::_('COM_LOCALISE_BUTTON_IMPORT') .
+			'</button>'
+	),
+	'<form method="post" action="' . JRoute::_('index.php?option=com_localise&task=package.uploadFile&file=' . $this->file) . '"
+        class="well" enctype="multipart/form-data" name="filemodalForm" id="filemodalForm">
+        <fieldset>
+            <input type="file" name="files" required />
+        </fieldset>
+    </form>'
+);

--- a/component/admin/views/translation/tmpl/edit.php
+++ b/component/admin/views/translation/tmpl/edit.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('stylesheet', 'com_localise/localise.css', null, true);
 
 $parts = explode('-', $this->state->get('translation.reference'));

--- a/component/admin/views/translation/tmpl/raw.php
+++ b/component/admin/views/translation/tmpl/raw.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHTML::_('stylesheet', 'com_localise/localise.css', null, true);
 

--- a/component/admin/views/translations/tmpl/default.php
+++ b/component/admin/views/translations/tmpl/default.php
@@ -11,8 +11,16 @@ defined('_JEXEC') or die;
 
 JHtml::_('stylesheet', 'com_localise/localise.css', null, true);
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.framework', true);
 JHtml::_('bootstrap.tooltip');
+
+if (version_compare(JVERSION, '4.0', 'ge'))
+{
+	JHtml::_('behavior.core');
+}
+else
+{
+	JHtml::_('behavior.framework', true);
+}
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));

--- a/localise.xml
+++ b/localise.xml
@@ -8,7 +8,7 @@
 	<copyright>(C) 2020 Open Source Matters</copyright>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>https://github.com/joomla-projects/com_localise</authorUrl>
-	<version>4.0.38-dev</version>
+	<version>4.1.0-dev</version>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<description>COM_LOCALISE_XML_DESCRIPTION</description>
 	<scriptfile>install.php</scriptfile>


### PR DESCRIPTION
@infograf768 I'm not a com_localise expert but I think this roughly get this component working on J4 (the ui isn't pretty but it is functional). It should also keep working fine on J3 too.

- Use JLanguageHelper instead of JLanguage on 3.7 and higher
- Use namespaced version of ArrayHelper (we already used it one place in the translation model)
- Remove most uses of JError in J3
- Stop loading mootools for core.js (I don't think we're even using it?)
- Use bootstrap modal rather than legacy modal script
- Use newer formvalidation script that's decoupled from mootools
- Give asset table a default id of 0 (this matches the current J3 asset ID column properties in 3.9.27)